### PR TITLE
Add Apple SpeechAnalyzer as an optional local model

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ parrot setup                           # one-time setup: permissions + model dow
 parrot install --launch-at-login       # register a LaunchAgent (background daemon)
 parrot install --uninstall             # remove the LaunchAgent
 parrot doctor                          # check permissions + fn key setting
+parrot --model apple-speech            # macOS 26 local SpeechAnalyzer
 parrot models list                     # list available models
 parrot models download <id>            # pre-download a model
 parrot --model whisper-large-v3-turbo  # bigger, multilingual, slower first-run
@@ -43,6 +44,7 @@ parrot --no-overlay                    # disable the bottom-of-screen pill
 ## Stack
 
 - **Swift** — single SPM executable target
+- **SpeechAnalyzer** — system-managed local speech recognition on macOS 26+
 - **WhisperKit** — Whisper inference via CoreML, ANE-accelerated
 - **AVAudioEngine** — mic capture
 - **CGEventTap** — global hotkey

--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ parrot install --launch-at-login   # optional — runs in the background on logi
 
 **Requires:** macOS 14+ on Apple Silicon (M1 or newer). Transcription runs on the Apple Neural Engine via CoreML — so the installer refuses to run on Intel.
 
+The `apple-speech` model requires macOS 26+. To run it at login, use macOS
+26.3 or newer, add `/usr/local/bin/parrot` to **System Settings → Privacy &
+Security → Accessibility**, then install the agent with:
+
+```sh
+parrot install --launch-at-login --model apple-speech
+```
+
+macOS 26.1–26.2 cannot reliably add standalone executables to the Accessibility
+list. On those versions, run `parrot --model apple-speech` from an authorized
+terminal instead.
+
 The installer drops the binary in `/usr/local/bin/parrot`. Builds are unsigned for now, so the installer strips the quarantine xattr — once you've inspected the script you'll see exactly what it does.
 
 ## How to use
@@ -31,6 +43,7 @@ That's it. There is no record button, no stop button, no "send" — `fn` is the 
 parrot                                 # run in the foreground (^C to quit)
 parrot setup                           # one-time setup: permissions + model download
 parrot install --launch-at-login       # register a LaunchAgent (background daemon)
+parrot install --launch-at-login --model apple-speech
 parrot install --uninstall             # remove the LaunchAgent
 parrot doctor                          # check permissions + fn key setting
 parrot --model apple-speech            # macOS 26 local SpeechAnalyzer

--- a/Sources/parrot/Install.swift
+++ b/Sources/parrot/Install.swift
@@ -17,6 +17,9 @@ struct Install: ParsableCommand {
     @Flag(name: .long, help: "Remove the launch-at-login agent.")
     var uninstall: Bool = false
 
+    @Option(name: .long, help: "Model id for the launch-at-login daemon (for example, apple-speech).")
+    var model: String?
+
     func run() throws {
         if launchAtLogin == uninstall {
             FileHandle.standardError.write(Data(
@@ -45,10 +48,34 @@ struct Install: ParsableCommand {
 
     private func writeAgent() throws {
         let binary = try resolveBinaryPath()
+        var arguments = [binary, "run", "--skip-doctor"]
+        if let model {
+            guard model == SystemModel.appleSpeech.rawValue || ModelRegistry.find(model) != nil else {
+                FileHandle.standardError.write(Data(
+                    "unknown model: \(model)\nrun `parrot models list` to see options.\n".utf8
+                ))
+                throw ExitCode(64)
+            }
+            if model == SystemModel.appleSpeech.rawValue {
+                guard #available(macOS 26.3, *) else {
+                    FileHandle.standardError.write(Data(
+                        """
+                        launch-at-login with apple-speech requires macOS 26.3 or newer.
+                        On macOS 26.1–26.2, System Settings cannot reliably grant Accessibility
+                        access to the standalone parrot executable. Run
+                        `parrot --model apple-speech` from an authorized terminal instead.
+
+                        """.utf8
+                    ))
+                    throw ExitCode(1)
+                }
+            }
+            arguments.append(contentsOf: ["--model", model])
+        }
 
         let plist: [String: Any] = [
             "Label": Self.label,
-            "ProgramArguments": [binary, "run", "--skip-doctor"],
+            "ProgramArguments": arguments,
             "RunAtLoad": true,
             "KeepAlive": ["SuccessfulExit": false] as [String: Any],
             "ProcessType": "Interactive",
@@ -80,7 +107,13 @@ struct Install: ParsableCommand {
         print("✓ launch-at-login installed")
         print("  plist:  \(url.path)")
         print("  binary: \(binary)")
+        if let model {
+            print("  model:  \(model)")
+        }
         print("  logs:   /tmp/parrot.out.log, /tmp/parrot.err.log")
+        print()
+        print("Grant Accessibility access to \(binary) in")
+        print("System Settings → Privacy & Security → Accessibility.")
     }
 
     private func removeAgent() throws {

--- a/Sources/parrot/Parrot.swift
+++ b/Sources/parrot/Parrot.swift
@@ -31,7 +31,7 @@ struct Run: ParsableCommand {
     @Flag(name: .long, help: "Disable the on-screen recording overlay.")
     var noOverlay: Bool = false
 
-    @Option(name: .long, help: "Model id to use. Defaults to the recommended model.")
+    @Option(name: .long, help: "Model id to use. Use apple-speech for the system model; defaults to the recommended Whisper model.")
     var model: String?
 
     func run() throws {
@@ -45,23 +45,32 @@ struct Run: ParsableCommand {
             }
         }
 
-        let chosenModel: TranscriptionModel
-        if let id = model {
-            guard let m = ModelRegistry.find(id) else {
-                FileHandle.standardError.write(Data("unknown model: \(id)\n".utf8))
-                FileHandle.standardError.write(Data("run `parrot models list` to see options.\n".utf8))
+        let transcriber: any Transcriber
+        if model == SystemModel.appleSpeech.rawValue {
+            guard #available(macOS 26.0, *) else {
+                FileHandle.standardError.write(Data("apple-speech requires macOS 26 or newer\n".utf8))
                 throw ExitCode(1)
             }
-            chosenModel = m
+            transcriber = AppleSpeechTranscriber()
         } else {
-            guard let m = ModelRegistry.recommended() else {
-                FileHandle.standardError.write(Data("no models registered\n".utf8))
-                throw ExitCode(1)
+            let chosenModel: TranscriptionModel
+            if let id = model {
+                guard let found = ModelRegistry.find(id) else {
+                    FileHandle.standardError.write(Data("unknown model: \(id)\n".utf8))
+                    FileHandle.standardError.write(Data("run `parrot models list` to see options.\n".utf8))
+                    throw ExitCode(1)
+                }
+                chosenModel = found
+            } else {
+                guard let recommended = ModelRegistry.recommended() else {
+                    FileHandle.standardError.write(Data("no models registered\n".utf8))
+                    throw ExitCode(1)
+                }
+                chosenModel = recommended
             }
-            chosenModel = m
+            transcriber = WhisperKitTranscriber(model: chosenModel)
         }
-
-        let transcriber = WhisperKitTranscriber(model: chosenModel)
+        let activeModelID = transcriber.modelID
         let warmupSemaphore = DispatchSemaphore(value: 0)
         var warmupError: Error?
         Task.detached {
@@ -88,7 +97,7 @@ struct Run: ParsableCommand {
         if let overlay {
             capture.onLevel = { level in overlay.pushLevel(level) }
         }
-        let menuBar = MainActor.assumeIsolated { MenuBarController(modelID: chosenModel.id) }
+        let menuBar = MainActor.assumeIsolated { MenuBarController(modelID: activeModelID) }
 
         do {
             try monitor.start { event in
@@ -169,7 +178,7 @@ struct Run: ParsableCommand {
         sigint.resume()
         signal(SIGINT, SIG_IGN)
 
-        FileHandle.standardError.write(Data("listening on fn hold · model: \(chosenModel.id) · ^C to quit\n".utf8))
+        FileHandle.standardError.write(Data("listening on fn hold · model: \(activeModelID) · ^C to quit\n".utf8))
         app.run()
     }
 }
@@ -196,6 +205,7 @@ struct Models: ParsableCommand {
 
     struct List: ParsableCommand {
         func run() throws {
+            print("  apple-speech               system  [local]    Apple SpeechAnalyzer")
             for m in ModelRegistry.shared {
                 let star = m.recommended ? "★" : " "
                 let id = m.id.padding(toLength: 26, withPad: " ", startingAt: 0)
@@ -211,6 +221,10 @@ struct Models: ParsableCommand {
         @Argument(help: "Model id to download.") var id: String
 
         func run() throws {
+            if id == SystemModel.appleSpeech.rawValue {
+                print("apple-speech uses a system-managed model; run parrot --model apple-speech")
+                return
+            }
             guard let m = ModelRegistry.find(id) else {
                 print("unknown model: \(id)")
                 throw ExitCode(1)

--- a/Sources/parrot/Parrot.swift
+++ b/Sources/parrot/Parrot.swift
@@ -222,7 +222,11 @@ struct Models: ParsableCommand {
 
         func run() throws {
             if id == SystemModel.appleSpeech.rawValue {
-                print("apple-speech uses a system-managed model; run parrot --model apple-speech")
+                print("""
+                apple-speech is managed by macOS; Parrot does not download it.
+                If its speech assets are missing, enable Dictation in System Settings > Keyboard.
+                Run parrot --model apple-speech to use it.
+                """)
                 return
             }
             guard let m = ModelRegistry.find(id) else {

--- a/Sources/parrot/Transcription/AppleSpeechTranscriber.swift
+++ b/Sources/parrot/Transcription/AppleSpeechTranscriber.swift
@@ -1,0 +1,161 @@
+@preconcurrency import AVFoundation
+import Foundation
+import Speech
+
+@available(macOS 26.0, *)
+actor AppleSpeechTranscriber: Transcriber {
+    let modelID = SystemModel.appleSpeech.rawValue
+    private let requestedLocale: Locale
+    private var locale: Locale?
+
+    init(locale: Locale = .current) {
+        self.requestedLocale = locale
+    }
+
+    func warmUp() async throws {
+        if locale != nil { return }
+        guard SpeechTranscriber.isAvailable else {
+            throw AppleSpeechError.unavailable
+        }
+        guard let supported = await SpeechTranscriber.supportedLocale(equivalentTo: requestedLocale) else {
+            throw AppleSpeechError.unsupportedLocale(requestedLocale.identifier)
+        }
+
+        let transcriber = SpeechTranscriber(locale: supported, preset: .transcription)
+        let modules: [any SpeechModule] = [transcriber]
+        let status = await AssetInventory.status(forModules: modules)
+        guard status == .installed else {
+            throw AppleSpeechError.assetsNotInstalled(supported.identifier)
+        }
+        _ = try await AssetInventory.reserve(locale: supported)
+        self.locale = supported
+        FileHandle.standardError.write(Data("✓ \(modelID) ready (\(supported.identifier))\n".utf8))
+    }
+
+    func transcribe(_ audio: [Float]) async throws -> String {
+        if locale == nil { try await warmUp() }
+        guard let locale else { throw TranscriberError.notLoaded }
+        guard !audio.isEmpty else { return "" }
+
+        let sourceFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: AudioCapture.targetSampleRate,
+            channels: 1,
+            interleaved: false
+        )!
+        guard let sourceBuffer = AVAudioPCMBuffer(
+            pcmFormat: sourceFormat,
+            frameCapacity: AVAudioFrameCount(audio.count)
+        ), let channel = sourceBuffer.floatChannelData?[0] else {
+            throw AppleSpeechError.audioBufferCreationFailed
+        }
+        sourceBuffer.frameLength = AVAudioFrameCount(audio.count)
+        audio.withUnsafeBufferPointer { samples in
+            channel.update(from: samples.baseAddress!, count: audio.count)
+        }
+
+        let transcriber = SpeechTranscriber(locale: locale, preset: .transcription)
+        let modules: [any SpeechModule] = [transcriber]
+        guard let analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(
+            compatibleWith: modules,
+            considering: sourceFormat
+        ) else {
+            throw AppleSpeechError.noCompatibleAudioFormat
+        }
+        let analyzerBuffer = try Self.convert(
+            sourceBuffer,
+            from: sourceFormat,
+            to: analyzerFormat
+        )
+        let options = SpeechAnalyzer.Options(priority: .userInitiated, modelRetention: .processLifetime)
+        let analyzer = SpeechAnalyzer(modules: modules, options: options)
+        try await analyzer.prepareToAnalyze(in: analyzerFormat)
+
+        let input = AsyncStream<AnalyzerInput> { continuation in
+            continuation.yield(AnalyzerInput(buffer: analyzerBuffer))
+            continuation.finish()
+        }
+        async let resultText = Self.collectResults(from: transcriber)
+        if let lastSampleTime = try await analyzer.analyzeSequence(input) {
+            try await analyzer.finalizeAndFinish(through: lastSampleTime)
+        } else {
+            await analyzer.cancelAndFinishNow()
+        }
+        return try await resultText
+    }
+
+    private static func convert(
+        _ source: AVAudioPCMBuffer,
+        from sourceFormat: AVAudioFormat,
+        to destinationFormat: AVAudioFormat
+    ) throws -> AVAudioPCMBuffer {
+        if sourceFormat == destinationFormat {
+            return source
+        }
+        guard let converter = AVAudioConverter(from: sourceFormat, to: destinationFormat) else {
+            throw AppleSpeechError.audioConversionFailed
+        }
+        let ratio = destinationFormat.sampleRate / sourceFormat.sampleRate
+        let capacity = AVAudioFrameCount(ceil(Double(source.frameLength) * ratio)) + 64
+        guard let output = AVAudioPCMBuffer(
+            pcmFormat: destinationFormat,
+            frameCapacity: capacity
+        ) else {
+            throw AppleSpeechError.audioBufferCreationFailed
+        }
+
+        var suppliedInput = false
+        var conversionError: NSError?
+        let status = converter.convert(to: output, error: &conversionError) { _, inputStatus in
+            if suppliedInput {
+                inputStatus.pointee = .endOfStream
+                return nil
+            }
+            suppliedInput = true
+            inputStatus.pointee = .haveData
+            return source
+        }
+        guard status != .error else {
+            throw conversionError ?? AppleSpeechError.audioConversionFailed
+        }
+        return output
+    }
+
+    private static func collectResults(from transcriber: SpeechTranscriber) async throws -> String {
+        var parts: [String] = []
+        for try await result in transcriber.results {
+            let text = String(result.text.characters)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if !text.isEmpty {
+                parts.append(text)
+            }
+        }
+        return parts.joined(separator: " ")
+    }
+}
+
+enum AppleSpeechError: LocalizedError {
+    case unavailable
+    case unsupportedLocale(String)
+    case assetsNotInstalled(String)
+    case audioBufferCreationFailed
+    case noCompatibleAudioFormat
+    case audioConversionFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .unavailable:
+            return "Apple SpeechAnalyzer is unavailable on this Mac"
+        case .unsupportedLocale(let locale):
+            return "Apple SpeechAnalyzer does not support \(locale)"
+        case .assetsNotInstalled(let locale):
+            return "Apple Speech assets for \(locale) are not installed; enable on-device Dictation in System Settings first"
+        case .audioBufferCreationFailed:
+            return "Could not create an Apple Speech audio buffer"
+        case .noCompatibleAudioFormat:
+            return "Apple Speech has no compatible audio format for the installed model"
+        case .audioConversionFailed:
+            return "Could not convert audio into Apple Speech's required format"
+        }
+    }
+}

--- a/Sources/parrot/Transcription/Transcriber.swift
+++ b/Sources/parrot/Transcription/Transcriber.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-protocol Transcriber {
+protocol Transcriber: Sendable {
     var modelID: String { get }
     func warmUp() async throws
     func transcribe(_ audio: [Float]) async throws -> String

--- a/Sources/parrot/Transcription/Transcriber.swift
+++ b/Sources/parrot/Transcription/Transcriber.swift
@@ -2,5 +2,10 @@ import Foundation
 
 protocol Transcriber {
     var modelID: String { get }
+    func warmUp() async throws
     func transcribe(_ audio: [Float]) async throws -> String
+}
+
+enum SystemModel: String, CaseIterable {
+    case appleSpeech = "apple-speech"
 }


### PR DESCRIPTION
## Summary

- add `apple-speech` as an optional transcription model on macOS 26+
- keep `whisper-base.en` as the default and retain every existing Whisper option
- list Apple Speech in `parrot models list`
- explain that Apple manages the model when `parrot models download apple-speech` is used
- allow launch-at-login to persist an explicit model selection

## Implementation

`AppleSpeechTranscriber` uses the system SpeechAnalyzer framework and the current locale. It requires the corresponding on-device speech assets to already be installed, so Parrot does not download another model.

Captured 16 kHz mono audio is converted to SpeechAnalyzer compatible format before analysis. The analyzer is finalized through its reported sample time, avoiding the trace trap caused by ending analysis incorrectly.

The installer now accepts `--model`, validates the model ID, and writes it into the LaunchAgent's `ProgramArguments`. Running without `--model` continues to use the recommended Whisper model.

## Launch-at-login requirement

Foreground Apple Speech requires macOS 26+. Launch-at-login with `apple-speech` requires macOS 26.3+ and Accessibility access for `/usr/local/bin/parrot` itself, because the LaunchAgent does not inherit the terminal's permission.

macOS 26.1–26.2 have a confirmed Privacy & Security bug that prevents standalone executables from being added reliably. On those versions, Parrot prints an actionable error and users can run the model from an authorized terminal instead. [Apple Developer Forums](https://developer.apple.com/forums/thread/808897)

```sh
parrot install --launch-at-login --model apple-speech
```

## Reported performance

In a third-party English LibriSpeech benchmark, SpeechAnalyzer reported 2.12%/4.56% WER versus 3.74%/7.95% for Whisper Small and 5.42%/12.51% for Whisper Base, while running about 3× faster than Small on an M2 Pro. [Methodology and limitations](https://get-inscribe.com/blog/apple-speech-api-benchmark.html).

## Usage

```sh
parrot --model apple-speech
```

Running `parrot` without `--model` continues to use the recommended Whisper model.

## Testing

- `swift build -c release`
- `swift build -Xswiftc -strict-concurrency=complete`
- `parrot models list`
- `parrot models download apple-speech`
- manually exercised foreground Apple Speech model loading and local transcription
- manually exercised the LaunchAgent end to end on macOS 26.6 with `/usr/local/bin/parrot` granted Accessibility access; confirmed `apple-speech` initialized and Fn dictation inserted text
