### PR TITLE
Configurable hotkey, paste-based injection, overlay above full-screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,35 @@ parrot models list                     # list available models
 parrot models download <id>            # pre-download a model
 parrot --model whisper-large-v3-turbo  # bigger, multilingual, slower first-run
 parrot --hotkey right-option           # change the push-to-talk key
+parrot --inject-mode type-unicode      # type the text instead of pasting it
 parrot --no-overlay                    # disable the bottom-of-screen pill
 ```
+
+### Non-Apple keyboards
+
+`fn` only exists as far as macOS is concerned on Apple keyboards. Third-party
+keyboards handle their `Fn` key entirely in firmware — it reshapes the F-row
+locally and never sends anything to the host, so no application can bind to it.
+On those, pick another modifier:
+
+```sh
+parrot --hotkey left-option
+```
+
+`--hotkey` accepts `fn`, and the left/right variants of `option`, `command`,
+`control`, and `shift`. Run `parrot run --debug-hotkey` to print the keycodes
+your keyboard actually emits. Note that it logs every key you press while it
+runs, so use it to identify a key and then stop it.
+
+### Injection modes
+
+`--inject-mode paste` (the default) puts the transcript on the pasteboard,
+sends ⌘V, and restores your previous pasteboard contents. Terminals and
+Electron apps discard synthesized unicode key events but all handle paste, so
+this is the mode that works everywhere.
+
+`--inject-mode type-unicode` synthesizes the characters directly and never
+touches the pasteboard, at the cost of silently dropping text in those apps.
 
 ## Stack
 

--- a/Sources/parrot/Input/HotkeyMonitor.swift
+++ b/Sources/parrot/Input/HotkeyMonitor.swift
@@ -10,16 +10,60 @@ final class HotkeyMonitor {
     enum Event { case pressed, released }
     enum HotkeyError: Error { case tapCreateFailed }
 
-    /// Mask of the modifier we treat as the hotkey. Fn = `.maskSecondaryFn`.
-    private let mask: CGEventFlags
+    /// A modifier key usable as push-to-talk.
+    ///
+    /// `mask` is the flag the modifier raises; `keycode` disambiguates the
+    /// left and right instances of a modifier, which share a single flag.
+    /// Fn uses no keycode filter — Apple keyboards raise `.maskSecondaryFn`
+    /// on their own, and third-party keyboards never send Fn to the host at
+    /// all (it is a firmware-local modifier), which is why they need one of
+    /// the other options here.
+    enum Hotkey: String, CaseIterable {
+        case fn
+        case rightOption = "right-option"
+        case leftOption = "left-option"
+        case rightCommand = "right-command"
+        case leftCommand = "left-command"
+        case rightControl = "right-control"
+        case leftControl = "left-control"
+        case rightShift = "right-shift"
+        case leftShift = "left-shift"
+
+        var mask: CGEventFlags {
+            switch self {
+            case .fn: return .maskSecondaryFn
+            case .rightOption, .leftOption: return .maskAlternate
+            case .rightCommand, .leftCommand: return .maskCommand
+            case .rightControl, .leftControl: return .maskControl
+            case .rightShift, .leftShift: return .maskShift
+            }
+        }
+
+        /// Virtual keycode of the physical key, where it matters.
+        var keycode: Int64? {
+            switch self {
+            case .fn: return nil
+            case .rightOption: return 61
+            case .leftOption: return 58
+            case .rightCommand: return 54
+            case .leftCommand: return 55
+            case .rightControl: return 62
+            case .leftControl: return 59
+            case .rightShift: return 60
+            case .leftShift: return 56
+            }
+        }
+    }
+
+    private let hotkey: Hotkey
     private let debug: Bool
     private var onEvent: ((Event) -> Void)?
     private var tap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
     private var isPressed = false
 
-    init(mask: CGEventFlags = .maskSecondaryFn, debug: Bool = false) {
-        self.mask = mask
+    init(hotkey: Hotkey = .fn, debug: Bool = false) {
+        self.hotkey = hotkey
         self.debug = debug
     }
 
@@ -87,7 +131,12 @@ final class HotkeyMonitor {
                 ))
         }
         guard type == .flagsChanged else { return }
-        let pressed = event.flags.contains(mask)
+        // Left/right instances of a modifier share one flag, so filter on the
+        // physical key before reading the flag.
+        if let expected = hotkey.keycode {
+            guard event.getIntegerValueField(.keyboardEventKeycode) == expected else { return }
+        }
+        let pressed = event.flags.contains(hotkey.mask)
         guard pressed != isPressed else { return }
         isPressed = pressed
         onEvent?(pressed ? .pressed : .released)

--- a/Sources/parrot/Input/TextInjector.swift
+++ b/Sources/parrot/Input/TextInjector.swift
@@ -1,21 +1,120 @@
+import AppKit
 import CoreGraphics
 import Foundation
 
-/// Posts a string of text at the current cursor location by synthesizing
-/// keyboard events with `CGEventKeyboardSetUnicodeString`. Works in nearly
-/// every text field on macOS; some Electron apps and secure password fields
-/// can drop characters (platform constraint).
+/// Delivers the transcript to whatever holds the keyboard focus.
+@MainActor
 enum TextInjector {
-    /// Inject the given text at the current cursor location.
-    /// Splits long strings into chunks because the underlying API has a
-    /// per-event character limit (~20 chars).
-    static func inject(_ text: String) {
-        guard !text.isEmpty else { return }
+    enum Mode: String, CaseIterable {
+        /// Put the text on the pasteboard and synthesize ⌘V, then restore the
+        /// previous pasteboard contents. Terminals and Electron apps read key
+        /// events in ways that drop synthesized unicode, but all of them
+        /// implement paste.
+        case paste
+        /// Synthesize the characters directly. Leaves the pasteboard alone, but
+        /// silently loses text in apps that ignore unicode-string key events.
+        case typeUnicode = "type-unicode"
+    }
 
+    /// Grace period for the target app to read the pasteboard before we put the
+    /// user's previous contents back. Paste is asynchronous in the target, so
+    /// restoring immediately races it.
+    private static let pasteSettleDelay: TimeInterval = 0.25
+
+    static func inject(_ text: String, mode: Mode = .paste) {
+        guard !text.isEmpty else { return }
+        switch mode {
+        case .paste: pasteInject(text)
+        case .typeUnicode: unicodeInject(text)
+        }
+    }
+
+    // MARK: - Paste
+
+    /// The user's pasteboard, held while one or more injections are in flight.
+    private static var savedContents: [[NSPasteboard.PasteboardType: Data]]?
+    private static var restoreGeneration = 0
+
+    private static func pasteInject(_ text: String) {
+        let pasteboard = NSPasteboard.general
+
+        // Only snapshot when no restore is already pending. Two injections
+        // inside the settle delay would otherwise capture the first one's text
+        // as "the user's pasteboard" and restore that, losing the real contents.
+        if savedContents == nil {
+            savedContents = snapshot(pasteboard)
+        }
+        restoreGeneration &+= 1
+        let generation = restoreGeneration
+
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+        postCommandV()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + pasteSettleDelay) {
+            // Superseded by a later injection; that one owns the restore.
+            guard generation == restoreGeneration else { return }
+            if let saved = savedContents {
+                restore(saved, to: pasteboard)
+            }
+            savedContents = nil
+        }
+    }
+
+    /// Capture every representation of every item, not just the plain string —
+    /// otherwise dictating over a copied image or file silently destroys it.
+    private static func snapshot(
+        _ pasteboard: NSPasteboard
+    ) -> [[NSPasteboard.PasteboardType: Data]] {
+        (pasteboard.pasteboardItems ?? []).map { item in
+            var contents: [NSPasteboard.PasteboardType: Data] = [:]
+            for type in item.types {
+                if let data = item.data(forType: type) { contents[type] = data }
+            }
+            return contents
+        }
+    }
+
+    private static func restore(
+        _ snapshot: [[NSPasteboard.PasteboardType: Data]],
+        to pasteboard: NSPasteboard
+    ) {
+        pasteboard.clearContents()
+        guard !snapshot.isEmpty else { return }
+        pasteboard.writeObjects(
+            snapshot.map { contents in
+                let item = NSPasteboardItem()
+                for (type, data) in contents { item.setData(data, forType: type) }
+                return item
+            })
+    }
+
+    private static func postCommandV() {
+        // Keycode 9 is `v` on the ASCII-capable layout macOS uses to match
+        // command key equivalents, so this stays correct on non-QWERTY layouts.
+        let vKey: CGKeyCode = 9
+        let source = CGEventSource(stateID: .combinedSessionState)
+        guard
+            let down = CGEvent(keyboardEventSource: source, virtualKey: vKey, keyDown: true),
+            let up = CGEvent(keyboardEventSource: source, virtualKey: vKey, keyDown: false)
+        else { return }
+        // Set flags explicitly: any modifier the user is still physically
+        // holding would otherwise ride along and turn this into a different
+        // shortcut.
+        down.flags = .maskCommand
+        up.flags = .maskCommand
+        down.post(tap: .cgAnnotatedSessionEventTap)
+        up.post(tap: .cgAnnotatedSessionEventTap)
+    }
+
+    // MARK: - Unicode
+
+    /// Splits into chunks because the underlying API has a per-event character
+    /// limit (~20 chars).
+    private static func unicodeInject(_ text: String) {
         let utf16 = Array(text.utf16)
         let chunkSize = 20
         var index = 0
-
         while index < utf16.count {
             let end = min(index + chunkSize, utf16.count)
             var chunk = Array(utf16[index..<end])

--- a/Sources/parrot/Install.swift
+++ b/Sources/parrot/Install.swift
@@ -17,6 +17,12 @@ struct Install: ParsableCommand {
     @Flag(name: .long, help: "Remove the launch-at-login agent.")
     var uninstall: Bool = false
 
+    @Option(name: .long, help: "Push-to-talk modifier to bake into the agent.")
+    var hotkey: HotkeyMonitor.Hotkey = .fn
+
+    @Option(name: .long, help: "Injection mode to bake into the agent.")
+    var injectMode: TextInjector.Mode = .paste
+
     func run() throws {
         if launchAtLogin == uninstall {
             FileHandle.standardError.write(Data(
@@ -48,7 +54,11 @@ struct Install: ParsableCommand {
 
         let plist: [String: Any] = [
             "Label": Self.label,
-            "ProgramArguments": [binary, "run", "--skip-doctor"],
+            "ProgramArguments": [
+                binary, "run", "--skip-doctor",
+                "--hotkey", hotkey.rawValue,
+                "--inject-mode", injectMode.rawValue,
+            ],
             "RunAtLoad": true,
             "KeepAlive": ["SuccessfulExit": false] as [String: Any],
             "ProcessType": "Interactive",

--- a/Sources/parrot/Parrot.swift
+++ b/Sources/parrot/Parrot.swift
@@ -13,6 +13,9 @@ struct Parrot: ParsableCommand {
     )
 }
 
+extension HotkeyMonitor.Hotkey: ExpressibleByArgument {}
+extension TextInjector.Mode: ExpressibleByArgument {}
+
 struct Run: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "run",
@@ -33,6 +36,25 @@ struct Run: ParsableCommand {
 
     @Option(name: .long, help: "Model id to use. Defaults to the recommended model.")
     var model: String?
+
+    @Option(
+        name: .long,
+        help: ArgumentHelp(
+            "Push-to-talk modifier to hold.",
+            discussion: "Third-party keyboards handle Fn in firmware and never send it to macOS; "
+                + "pick another modifier on those. Options: "
+                + HotkeyMonitor.Hotkey.allCases.map(\.rawValue).joined(separator: ", ")
+        ))
+    var hotkey: HotkeyMonitor.Hotkey = .fn
+
+    @Option(
+        name: .long,
+        help: ArgumentHelp(
+            "How the transcript is delivered to the focused app.",
+            discussion: "paste briefly uses the pasteboard and works in terminals and Electron "
+                + "apps; type-unicode leaves the pasteboard untouched but is dropped by some apps."
+        ))
+    var injectMode: TextInjector.Mode = .paste
 
     func run() throws {
         if !skipDoctor {
@@ -81,14 +103,16 @@ struct Run: ParsableCommand {
         let app = NSApplication.shared
         app.setActivationPolicy(.accessory)
 
-        let monitor = HotkeyMonitor(debug: debugHotkey)
+        let monitor = HotkeyMonitor(hotkey: hotkey, debug: debugHotkey)
         let capture = AudioCapture()
         let dumpWav = self.dumpWav
         let overlay: RecordingOverlay? = noOverlay ? nil : MainActor.assumeIsolated { RecordingOverlay() }
         if let overlay {
             capture.onLevel = { level in overlay.pushLevel(level) }
         }
-        let menuBar = MainActor.assumeIsolated { MenuBarController(modelID: chosenModel.id) }
+        let menuBar = MainActor.assumeIsolated {
+            MenuBarController(modelID: chosenModel.id, hotkeyLabel: hotkey.rawValue)
+        }
 
         do {
             try monitor.start { event in
@@ -140,7 +164,7 @@ struct Run: ParsableCommand {
                                 String(format: "→ %.2fs · %@\n", elapsed, text).utf8
                             ))
                             await MainActor.run {
-                                TextInjector.inject(text)
+                                TextInjector.inject(text, mode: injectMode)
                                 overlay?.hide()
                                 menuBar.setRecording(false)
                             }
@@ -169,7 +193,8 @@ struct Run: ParsableCommand {
         sigint.resume()
         signal(SIGINT, SIG_IGN)
 
-        FileHandle.standardError.write(Data("listening on fn hold · model: \(chosenModel.id) · ^C to quit\n".utf8))
+        FileHandle.standardError.write(
+            Data("listening on \(hotkey.rawValue) hold · model: \(chosenModel.id) · ^C to quit\n".utf8))
         app.run()
     }
 }

--- a/Sources/parrot/UI/MenuBarController.swift
+++ b/Sources/parrot/UI/MenuBarController.swift
@@ -9,15 +9,17 @@ final class MenuBarController {
     private let modelLabel: NSMenuItem
     private let stateLabel: NSMenuItem
     private let modelID: String
+    private let idleTitle: String
 
-    init(modelID: String) {
+    init(modelID: String, hotkeyLabel: String) {
         self.modelID = modelID
+        self.idleTitle = "idle · hold \(hotkeyLabel) to dictate"
         self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
 
         let menu = NSMenu()
         menu.autoenablesItems = false
 
-        stateLabel = NSMenuItem(title: "idle · hold fn to dictate", action: nil, keyEquivalent: "")
+        stateLabel = NSMenuItem(title: idleTitle, action: nil, keyEquivalent: "")
         stateLabel.isEnabled = false
         menu.addItem(stateLabel)
 
@@ -40,7 +42,7 @@ final class MenuBarController {
     }
 
     func setRecording(_ recording: Bool) {
-        stateLabel.title = recording ? "● recording" : "idle · hold fn to dictate"
+        stateLabel.title = recording ? "● recording" : idleTitle
     }
 
     func setTranscribing() {

--- a/Sources/parrot/UI/RecordingOverlay.swift
+++ b/Sources/parrot/UI/RecordingOverlay.swift
@@ -13,17 +13,24 @@ final class RecordingOverlay {
 
     private var window: NSPanel?
     private let model = OverlayModel()
+    /// Invalidates a pending `hide()` when a new recording starts inside the
+    /// dismiss animation window, which would otherwise order the freshly shown
+    /// panel back out.
+    private var hideGeneration = 0
 
     func show(_ state: State) {
         ensureWindow()
+        guard let window else { return }
+        hideGeneration &+= 1
         if state == .recording {
             model.resetLevels()
         }
-        guard let window else { return }
-        let needsAppear = !window.isVisible
-        if needsAppear {
-            positionAtBottomCenter(window)
-            window.orderFrontRegardless()
+        let wasHidden = !window.isVisible
+        // Reposition and re-order on every show: the active screen and Space
+        // can both change between recordings.
+        position(window)
+        window.orderFrontRegardless()
+        if wasHidden {
             // Defer the state change so SwiftUI lays out in the .hidden style
             // first, then animates to the visible style on the next runloop tick.
             DispatchQueue.main.async { [model] in
@@ -36,11 +43,13 @@ final class RecordingOverlay {
 
     func hide() {
         model.state = .hidden
+        hideGeneration &+= 1
+        let generation = hideGeneration
         // Let the SwiftUI scale+fade animation play out before yanking the
         // window — otherwise it just pops away.
-        let window = self.window
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.18) {
-            window?.orderOut(nil)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.18) { [weak self] in
+            guard let self, self.hideGeneration == generation else { return }
+            self.window?.orderOut(nil)
         }
     }
 
@@ -60,7 +69,9 @@ final class RecordingOverlay {
             defer: false
         )
         panel.isFloatingPanel = true
-        panel.level = .statusBar
+        // Above full-screen windows, which sit above .statusBar. Without this
+        // the pill is invisible whenever the frontmost app is full-screen.
+        panel.level = .screenSaver
         panel.isOpaque = false
         panel.backgroundColor = .clear
         panel.hasShadow = true
@@ -76,8 +87,15 @@ final class RecordingOverlay {
         window = panel
     }
 
-    private func positionAtBottomCenter(_ window: NSPanel) {
-        guard let screen = NSScreen.main else { return }
+    private func position(_ window: NSPanel) {
+        // `NSScreen.main` follows keyboard focus and is nil when no window has
+        // it — unreliable for a background agent. The screen under the pointer
+        // is the one the user is looking at.
+        let pointer = NSEvent.mouseLocation
+        guard
+            let screen = NSScreen.screens.first(where: { $0.frame.contains(pointer) })
+                ?? NSScreen.main ?? NSScreen.screens.first
+        else { return }
         let frame = window.frame
         let visible = screen.visibleFrame
         let x = visible.midX - frame.width / 2


### PR DESCRIPTION
Three things the docs promise that the code never implemented. Each one makes parrot unusable on some setup.

### `--hotkey`

`HotkeyMonitor` hardcoded `.maskSecondaryFn`, so the README's `parrot --hotkey right-option` did nothing.

This matters more than a missing flag: non-Apple keyboards handle Fn in firmware. It reshapes the F-row locally and never sends anything to the host, so no application can bind to it. On a Mac mini with a third-party keyboard there is no working key at all — parrot waits forever for an event the hardware cannot produce.

Adds a `Hotkey` enum for fn plus the left/right variants of option, command, control and shift. Left and right share one event flag, so each case carries a keycode and the monitor filters on it before reading the flag.

### `--inject-mode`

`CGEventKeyboardSetUnicodeString` is discarded by terminals and WebKit/Electron-hosted UIs, which read key events directly. Dictation worked in Safari and silently produced nothing in a terminal.

Adds the `inject_mode` from `docs/architecture.md`, defaulting to `paste`: stage the text, send ⌘V, restore the pasteboard. Two details worth reviewing:

- the snapshot preserves every representation of every item, so dictating while an image or file is copied doesn't destroy it
- a pending restore suppresses re-snapshotting, so two transcripts inside the settle window can't leave the first one on the pasteboard permanently

Verified in a terminal. `type-unicode` remains available for anyone who wants the pasteboard untouched.

### Overlay

The pill sat at `.statusBar`, below full-screen windows, so it was invisible whenever the frontmost app was full-screen — measured as `layer=25 onscreen=false` during an active recording. Now `.screenSaver`.

Also repositions on every show, since the active screen and Space change between recordings; picks the screen under the pointer rather than `NSScreen.main`, which follows keyboard focus and is nil for a background agent; and generation-guards the dismiss timer so a recording started inside the 0.18s animation isn't ordered back out by the previous hide.

### Install

The LaunchAgent hardcoded its arguments, so launch-at-login silently reverted both new settings. Easy to miss — it only bites after a reboot.

---

Default choice worth a second opinion: `paste` briefly touches the clipboard. It's the mode that works everywhere, which is why it's the default, but `type-unicode` as default is a one-line change if you'd rather not touch the pasteboard by default.

Tested on macOS 26.5 / M4 with a Logitech keyboard, on `left-option` + `paste`. The other seven modifiers share one code path and a keycode table, but only `left-option` was exercised on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)