### PR TITLE
Add locked Fn dictation and optional output mute

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,5 +16,9 @@ let package = Package(
                 .product(name: "WhisperKit", package: "WhisperKit"),
             ]
         ),
+        .testTarget(
+            name: "parrotTests",
+            dependencies: ["parrot"]
+        ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ The installer drops the binary in `/usr/local/bin/parrot`. Builds are unsigned f
 1. **Run it.** Either `parrot install --launch-at-login` (daemonized, runs forever, lives in the menu bar), or `parrot` in any terminal tab.
 2. **Click into the text field you want to dictate into** — Messages, the address bar, a Slack thread, anywhere a cursor blinks.
 3. **Hold the `fn` key, speak, release.** A small pill appears at the bottom of the screen while the mic is hot.
-4. **The transcript types itself in at the cursor** when you release. Usually within 200-300ms.
+4. **For hands-free dictation, double-tap `fn`.** The recording stays active and a lock appears beside the waveform.
+5. **Tap `fn` once to stop a locked dictation.** Parrot restores audio, transcribes, and types at the cursor.
+6. **The transcript types itself in at the cursor** after recording stops. Usually within 200-300ms.
 
 That's it. There is no record button, no stop button, no "send" — `fn` is the whole interface.
 
@@ -37,8 +39,16 @@ parrot models list                     # list available models
 parrot models download <id>            # pre-download a model
 parrot --model whisper-large-v3-turbo  # bigger, multilingual, slower first-run
 parrot --hotkey right-option           # change the push-to-talk key
+parrot --mute-output                    # silence current output while recording
 parrot --no-overlay                    # disable the bottom-of-screen pill
 ```
+
+## Mute while dictating
+
+Pass `--mute-output` to temporarily mute the active macOS audio output while
+recording. Parrot restores the previous mute or volume state when recording
+stops, keeping browser, Spotify, and other currently-playing audio out of the
+microphone.
 
 ## Stack
 

--- a/Sources/parrot/Audio/OutputMuteController.swift
+++ b/Sources/parrot/Audio/OutputMuteController.swift
@@ -1,0 +1,216 @@
+import AudioToolbox
+import CoreAudio
+import Foundation
+
+/// Temporarily silences the current macOS output route while Parrot records.
+///
+/// It prefers the hardware mute control and falls back to the output volume for
+/// Bluetooth/AirPods-style devices. The original state is captured once and is
+/// restored as soon as the Fn key is released.
+final class OutputMuteController {
+    private enum SilenceState {
+        case mute(deviceID: AudioDeviceID, wasMuted: Bool)
+        case volume(deviceID: AudioDeviceID, controls: [VolumeControl])
+    }
+
+    private struct VolumeControl {
+        let address: AudioObjectPropertyAddress
+        let previousVolume: Float32
+    }
+
+    private var state: SilenceState?
+
+    func mute() {
+        guard state == nil else { return }
+
+        do {
+            let deviceID = try defaultOutputDeviceID()
+            do {
+                let wasMuted = try isMuted(deviceID: deviceID)
+                try setMuted(true, deviceID: deviceID)
+                state = .mute(deviceID: deviceID, wasMuted: wasMuted)
+                log("muted \(deviceName(deviceID: deviceID))")
+            } catch {
+                let controls = try readVolumeControls(deviceID: deviceID)
+                try setVolume(0, controls: controls, deviceID: deviceID)
+                state = .volume(deviceID: deviceID, controls: controls)
+                log("muted \(deviceName(deviceID: deviceID)) using volume fallback")
+            }
+        } catch {
+            log("mute failed: \(error)")
+        }
+    }
+
+    func restore() {
+        guard let state else { return }
+
+        do {
+            switch state {
+            case .mute(let deviceID, let wasMuted):
+                try setMuted(wasMuted, deviceID: deviceID)
+                log("restored \(deviceName(deviceID: deviceID))")
+            case .volume(let deviceID, let controls):
+                try restoreVolume(controls, deviceID: deviceID)
+                log("restored volume for \(deviceName(deviceID: deviceID))")
+            }
+            self.state = nil
+        } catch {
+            log("restore failed: \(error)")
+        }
+    }
+
+    deinit {
+        restore()
+    }
+
+    private func defaultOutputDeviceID() throws -> AudioDeviceID {
+        var deviceID = AudioDeviceID(0)
+        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        let status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size, &deviceID
+        )
+        guard status == noErr, deviceID != AudioDeviceID(kAudioObjectUnknown) else {
+            throw OutputMuteError.defaultOutputUnavailable(status)
+        }
+        return deviceID
+    }
+
+    private func isMuted(deviceID: AudioDeviceID) throws -> Bool {
+        var muted = UInt32(0)
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        var address = mutePropertyAddress()
+        let status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &muted)
+        guard status == noErr else { throw OutputMuteError.readMute(status) }
+        return muted != 0
+    }
+
+    private func setMuted(_ muted: Bool, deviceID: AudioDeviceID) throws {
+        var value = UInt32(muted ? 1 : 0)
+        var address = mutePropertyAddress()
+        guard AudioObjectHasProperty(deviceID, &address) else {
+            throw OutputMuteError.writeMute(kAudioHardwareUnknownPropertyError)
+        }
+        let status = AudioObjectSetPropertyData(
+            deviceID, &address, 0, nil, UInt32(MemoryLayout<UInt32>.size), &value
+        )
+        guard status == noErr else { throw OutputMuteError.writeMute(status) }
+    }
+
+    private func readVolumeControls(deviceID: AudioDeviceID) throws -> [VolumeControl] {
+        if let control = try? readVolumeControl(
+            deviceID: deviceID,
+            address: volumePropertyAddress()
+        ) {
+            return [control]
+        }
+        if let control = try? readVolumeControl(
+            deviceID: deviceID,
+            address: scalarVolumePropertyAddress(element: kAudioObjectPropertyElementMain)
+        ) {
+            return [control]
+        }
+        let channels = [AudioObjectPropertyElement(1), AudioObjectPropertyElement(2)].compactMap { element in
+            try? readVolumeControl(
+                deviceID: deviceID,
+                address: scalarVolumePropertyAddress(element: element)
+            )
+        }
+        guard !channels.isEmpty else {
+            throw OutputMuteError.readVolume(kAudioHardwareUnknownPropertyError)
+        }
+        return channels
+    }
+
+    private func readVolumeControl(
+        deviceID: AudioDeviceID,
+        address: AudioObjectPropertyAddress
+    ) throws -> VolumeControl {
+        var value = Float32(0)
+        var mutableAddress = address
+        var size = UInt32(MemoryLayout<Float32>.size)
+        guard AudioObjectHasProperty(deviceID, &mutableAddress) else {
+            throw OutputMuteError.readVolume(kAudioHardwareUnknownPropertyError)
+        }
+        let status = AudioObjectGetPropertyData(
+            deviceID, &mutableAddress, 0, nil, &size, &value
+        )
+        guard status == noErr else { throw OutputMuteError.readVolume(status) }
+        return VolumeControl(address: address, previousVolume: value)
+    }
+
+    private func setVolume(_ volume: Float32, controls: [VolumeControl], deviceID: AudioDeviceID) throws {
+        for control in controls {
+            var value = min(max(volume, 0), 1)
+            var address = control.address
+            let size = UInt32(MemoryLayout<Float32>.size)
+            let status = AudioObjectSetPropertyData(
+                deviceID, &address, 0, nil, size, &value
+            )
+            guard status == noErr else { throw OutputMuteError.writeVolume(status) }
+        }
+    }
+
+    private func restoreVolume(_ controls: [VolumeControl], deviceID: AudioDeviceID) throws {
+        if let currentControls = try? readVolumeControls(deviceID: deviceID),
+           let previousVolume = controls.first?.previousVolume {
+            try setVolume(previousVolume, controls: currentControls, deviceID: deviceID)
+        } else {
+            try setVolume(controls.first?.previousVolume ?? 0, controls: controls, deviceID: deviceID)
+        }
+    }
+
+    private func mutePropertyAddress() -> AudioObjectPropertyAddress {
+        AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyMute,
+            mScope: kAudioDevicePropertyScopeOutput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+    }
+
+    private func volumePropertyAddress() -> AudioObjectPropertyAddress {
+        AudioObjectPropertyAddress(
+            mSelector: kAudioHardwareServiceDeviceProperty_VirtualMainVolume,
+            mScope: kAudioDevicePropertyScopeOutput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+    }
+
+    private func scalarVolumePropertyAddress(element: AudioObjectPropertyElement) -> AudioObjectPropertyAddress {
+        AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyVolumeScalar,
+            mScope: kAudioDevicePropertyScopeOutput,
+            mElement: element
+        )
+    }
+
+    private func deviceName(deviceID: AudioDeviceID) -> String {
+        var name: CFString = "default output" as CFString
+        var size = UInt32(MemoryLayout<CFString>.size)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioObjectPropertyName,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        let status = withUnsafeMutablePointer(to: &name) {
+            AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, $0)
+        }
+        return status == noErr ? name as String : "default output"
+    }
+
+    private func log(_ message: String) {
+        FileHandle.standardError.write(Data("parrot audio: \(message)\n".utf8))
+    }
+}
+
+private enum OutputMuteError: Error {
+    case defaultOutputUnavailable(OSStatus)
+    case readMute(OSStatus)
+    case writeMute(OSStatus)
+    case readVolume(OSStatus)
+    case writeVolume(OSStatus)
+}

--- a/Sources/parrot/Input/FnDictationGesture.swift
+++ b/Sources/parrot/Input/FnDictationGesture.swift
@@ -1,0 +1,175 @@
+import Foundation
+
+/// Turns raw Fn press/release edges into push-to-talk or locked-dictation
+/// actions. The state machine is deliberately independent from audio and UI so
+/// every timing edge can be tested without installing an event tap.
+struct FnDictationGesture {
+    enum Input {
+        case pressed(at: TimeInterval)
+        case released(at: TimeInterval)
+        case secondTapTimedOut
+    }
+
+    enum Action: Equatable {
+        case startRecording
+        case stopRecording
+        case showLocked
+        case scheduleSecondTapTimeout(after: TimeInterval)
+        case cancelSecondTapTimeout
+    }
+
+    private enum Phase {
+        case idle
+        case firstPress(startedAt: TimeInterval)
+        case awaitingSecondTap
+        case lockCandidatePress(startedAt: TimeInterval)
+        case locked
+        case stopPressHeld
+    }
+
+    private(set) var isLocked = false
+    private var phase: Phase = .idle
+    let quickTapMaximumDuration: TimeInterval
+    let doubleTapInterval: TimeInterval
+
+    init(
+        quickTapMaximumDuration: TimeInterval = 0.30,
+        doubleTapInterval: TimeInterval = 0.40
+    ) {
+        self.quickTapMaximumDuration = quickTapMaximumDuration
+        self.doubleTapInterval = doubleTapInterval
+    }
+
+    mutating func handle(_ input: Input) -> [Action] {
+        switch (phase, input) {
+        case (.idle, let .pressed(time)):
+            phase = .firstPress(startedAt: time)
+            return [.startRecording]
+
+        case (let .firstPress(startedAt), let .released(time)):
+            if time - startedAt <= quickTapMaximumDuration {
+                phase = .awaitingSecondTap
+                return [.scheduleSecondTapTimeout(after: doubleTapInterval)]
+            }
+            phase = .idle
+            return [.stopRecording]
+
+        case (.awaitingSecondTap, let .pressed(time)):
+            phase = .lockCandidatePress(startedAt: time)
+            return [.cancelSecondTapTimeout]
+
+        case (.awaitingSecondTap, .secondTapTimedOut):
+            phase = .idle
+            return [.stopRecording]
+
+        case (let .lockCandidatePress(startedAt), let .released(time)):
+            if time - startedAt <= quickTapMaximumDuration {
+                phase = .locked
+                isLocked = true
+                return [.showLocked]
+            }
+            phase = .idle
+            return [.stopRecording]
+
+        case (.locked, .pressed):
+            phase = .stopPressHeld
+            return []
+
+        case (.stopPressHeld, .released):
+            phase = .idle
+            isLocked = false
+            return [.stopRecording]
+
+        default:
+            // Duplicate edges and cancelled timeout callbacks are harmless.
+            return []
+        }
+    }
+
+    mutating func reset() {
+        phase = .idle
+        isLocked = false
+    }
+
+    var hasActiveRecording: Bool {
+        if case .idle = phase { return false }
+        return true
+    }
+}
+
+/// Main-thread runtime wrapper responsible only for the double-tap timer and
+/// dispatching state-machine actions to the recording session.
+@MainActor
+final class FnDictationGestureController {
+    private var gesture: FnDictationGesture
+    private var timeoutWorkItem: DispatchWorkItem?
+    private let startRecording: () -> Bool
+    private let stopRecording: () -> Void
+    private let showLocked: () -> Void
+
+    init(
+        doubleTapInterval: TimeInterval,
+        startRecording: @escaping () -> Bool,
+        stopRecording: @escaping () -> Void,
+        showLocked: @escaping () -> Void
+    ) {
+        gesture = FnDictationGesture(doubleTapInterval: doubleTapInterval)
+        self.startRecording = startRecording
+        self.stopRecording = stopRecording
+        self.showLocked = showLocked
+    }
+
+    func handle(_ event: HotkeyMonitor.Event) {
+        if case .interrupted = event {
+            let shouldStop = gesture.hasActiveRecording
+            cancel()
+            if shouldStop {
+                stopRecording()
+            }
+            return
+        }
+
+        let now = ProcessInfo.processInfo.systemUptime
+        let input: FnDictationGesture.Input = switch event {
+        case .pressed: .pressed(at: now)
+        case .released: .released(at: now)
+        case .interrupted: fatalError("handled above")
+        }
+        perform(gesture.handle(input))
+    }
+
+    func cancel() {
+        timeoutWorkItem?.cancel()
+        timeoutWorkItem = nil
+        gesture.reset()
+    }
+
+    private func perform(_ actions: [FnDictationGesture.Action]) {
+        for action in actions {
+            switch action {
+            case .startRecording:
+                if !startRecording() {
+                    cancel()
+                }
+            case .stopRecording:
+                timeoutWorkItem?.cancel()
+                timeoutWorkItem = nil
+                stopRecording()
+            case .showLocked:
+                showLocked()
+            case let .scheduleSecondTapTimeout(delay):
+                timeoutWorkItem?.cancel()
+                let workItem = DispatchWorkItem { [weak self] in
+                    guard let self else { return }
+                    self.timeoutWorkItem = nil
+                    self.perform(self.gesture.handle(.secondTapTimedOut))
+                }
+                timeoutWorkItem = workItem
+                DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+            case .cancelSecondTapTimeout:
+                timeoutWorkItem?.cancel()
+                timeoutWorkItem = nil
+            }
+        }
+    }
+}

--- a/Sources/parrot/Input/HotkeyMonitor.swift
+++ b/Sources/parrot/Input/HotkeyMonitor.swift
@@ -7,7 +7,7 @@ import Foundation
 /// Requires Accessibility permission. If the tap fails to register, callers
 /// will see an error from `start()`.
 final class HotkeyMonitor {
-    enum Event { case pressed, released }
+    enum Event { case pressed, released, interrupted }
     enum HotkeyError: Error { case tapCreateFailed }
 
     /// Mask of the modifier we treat as the hotkey. Fn = `.maskSecondaryFn`.
@@ -92,6 +92,14 @@ final class HotkeyMonitor {
         isPressed = pressed
         onEvent?(pressed ? .pressed : .released)
     }
+
+    fileprivate func handleTapInterruption() {
+        if let tap {
+            CGEvent.tapEnable(tap: tap, enable: true)
+        }
+        isPressed = false
+        onEvent?(.interrupted)
+    }
 }
 
 private func hotkeyCallback(
@@ -104,8 +112,9 @@ private func hotkeyCallback(
     let monitor = Unmanaged<HotkeyMonitor>.fromOpaque(userInfo).takeUnretainedValue()
 
     if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-        // System disabled our tap; we'll need to re-enable. For now just no-op
-        // and let the user restart parrot.
+        DispatchQueue.main.async {
+            monitor.handleTapInterruption()
+        }
         return Unmanaged.passUnretained(event)
     }
 

--- a/Sources/parrot/Parrot.swift
+++ b/Sources/parrot/Parrot.swift
@@ -31,6 +31,9 @@ struct Run: ParsableCommand {
     @Flag(name: .long, help: "Disable the on-screen recording overlay.")
     var noOverlay: Bool = false
 
+    @Flag(name: .long, help: "Mute the active macOS output while recording.")
+    var muteOutput: Bool = false
+
     @Option(name: .long, help: "Model id to use. Defaults to the recommended model.")
     var model: String?
 
@@ -83,6 +86,7 @@ struct Run: ParsableCommand {
 
         let monitor = HotkeyMonitor(debug: debugHotkey)
         let capture = AudioCapture()
+        let outputMute = muteOutput ? OutputMuteController() : nil
         let dumpWav = self.dumpWav
         let overlay: RecordingOverlay? = noOverlay ? nil : MainActor.assumeIsolated { RecordingOverlay() }
         if let overlay {
@@ -90,68 +94,94 @@ struct Run: ParsableCommand {
         }
         let menuBar = MainActor.assumeIsolated { MenuBarController(modelID: chosenModel.id) }
 
+        func beginRecording() -> Bool {
+            outputMute?.mute()
+            do {
+                try capture.start()
+                FileHandle.standardError.write(Data("● recording\n".utf8))
+                MainActor.assumeIsolated {
+                    overlay?.show(.recording)
+                    menuBar.setRecording(true)
+                }
+                return true
+            } catch {
+                outputMute?.restore()
+                FileHandle.standardError.write(Data("capture failed: \(error)\n".utf8))
+                return false
+            }
+        }
+
+        func finishRecording() {
+            let samples = capture.stop()
+            outputMute?.restore()
+            MainActor.assumeIsolated {
+                overlay?.show(.transcribing)
+                menuBar.setTranscribing()
+            }
+            let seconds = Double(samples.count) / AudioCapture.targetSampleRate
+            let rms = computeRMS(samples)
+            FileHandle.standardError.write(Data(
+                String(format: "○ captured %.2fs · rms %.3f\n", seconds, rms).utf8
+            ))
+            if dumpWav, !samples.isEmpty {
+                let path = "/tmp/parrot-last.wav"
+                do {
+                    try WAVWriter.write(samples: samples, sampleRate: 16_000, to: path)
+                    FileHandle.standardError.write(Data("  wrote \(path)\n".utf8))
+                } catch {
+                    FileHandle.standardError.write(Data("  wav write failed: \(error)\n".utf8))
+                }
+            }
+            guard !samples.isEmpty else {
+                MainActor.assumeIsolated {
+                    overlay?.hide()
+                    menuBar.setRecording(false)
+                }
+                return
+            }
+            Task {
+                let started = Date()
+                do {
+                    let text = try await transcriber.transcribe(samples)
+                    let elapsed = Date().timeIntervalSince(started)
+                    FileHandle.standardError.write(Data(
+                        String(format: "→ %.2fs · %@\n", elapsed, text).utf8
+                    ))
+                    await MainActor.run {
+                        TextInjector.inject(text)
+                        overlay?.hide()
+                        menuBar.setRecording(false)
+                    }
+                } catch {
+                    FileHandle.standardError.write(Data("transcription failed: \(error)\n".utf8))
+                    await MainActor.run {
+                        overlay?.hide()
+                        menuBar.setRecording(false)
+                    }
+                }
+            }
+        }
+
+        // Respect the user's macOS double-click preference, while keeping the
+        // recognition window short enough to feel immediate for Fn dictation.
+        let doubleTapInterval = min(max(NSEvent.doubleClickInterval, 0.30), 0.50)
+        let gestureController = MainActor.assumeIsolated {
+            FnDictationGestureController(
+                doubleTapInterval: doubleTapInterval,
+                startRecording: beginRecording,
+                stopRecording: finishRecording,
+                showLocked: {
+                    FileHandle.standardError.write(Data("🔒 recording locked · tap fn to stop\n".utf8))
+                    overlay?.show(.locked)
+                    menuBar.setLockedRecording()
+                }
+            )
+        }
+
         do {
             try monitor.start { event in
-                switch event {
-                case .pressed:
-                    do {
-                        try capture.start()
-                        FileHandle.standardError.write(Data("● recording\n".utf8))
-                        MainActor.assumeIsolated {
-                            overlay?.show(.recording)
-                            menuBar.setRecording(true)
-                        }
-                    } catch {
-                        FileHandle.standardError.write(Data("capture failed: \(error)\n".utf8))
-                    }
-                case .released:
-                    let samples = capture.stop()
-                    MainActor.assumeIsolated {
-                        overlay?.show(.transcribing)
-                        menuBar.setTranscribing()
-                    }
-                    let seconds = Double(samples.count) / AudioCapture.targetSampleRate
-                    let rms = computeRMS(samples)
-                    FileHandle.standardError.write(Data(
-                        String(format: "○ captured %.2fs · rms %.3f\n", seconds, rms).utf8
-                    ))
-                    if dumpWav, !samples.isEmpty {
-                        let path = "/tmp/parrot-last.wav"
-                        do {
-                            try WAVWriter.write(samples: samples, sampleRate: 16_000, to: path)
-                            FileHandle.standardError.write(Data("  wrote \(path)\n".utf8))
-                        } catch {
-                            FileHandle.standardError.write(Data("  wav write failed: \(error)\n".utf8))
-                        }
-                    }
-                    guard !samples.isEmpty else {
-                        MainActor.assumeIsolated {
-                            overlay?.hide()
-                            menuBar.setRecording(false)
-                        }
-                        return
-                    }
-                    Task {
-                        let started = Date()
-                        do {
-                            let text = try await transcriber.transcribe(samples)
-                            let elapsed = Date().timeIntervalSince(started)
-                            FileHandle.standardError.write(Data(
-                                String(format: "→ %.2fs · %@\n", elapsed, text).utf8
-                            ))
-                            await MainActor.run {
-                                TextInjector.inject(text)
-                                overlay?.hide()
-                                menuBar.setRecording(false)
-                            }
-                        } catch {
-                            FileHandle.standardError.write(Data("transcription failed: \(error)\n".utf8))
-                            await MainActor.run {
-                                overlay?.hide()
-                                menuBar.setRecording(false)
-                            }
-                        }
-                    }
+                MainActor.assumeIsolated {
+                    gestureController.handle(event)
                 }
             }
         } catch {
@@ -160,17 +190,41 @@ struct Run: ParsableCommand {
             throw ExitCode(1)
         }
 
-        let sigint = DispatchSource.makeSignalSource(signal: SIGINT, queue: .main)
-        sigint.setEventHandler {
+        let cleanUp = {
+            MainActor.assumeIsolated {
+                gestureController.cancel()
+            }
+            _ = capture.stop()
+            outputMute?.restore()
+        }
+        let terminationObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.willTerminateNotification,
+            object: app,
+            queue: .main
+        ) { _ in
+            cleanUp()
+        }
+
+        let shutDown = {
             FileHandle.standardError.write(Data("\nshutting down\n".utf8))
             monitor.stop()
+            cleanUp()
             NSApp.terminate(nil)
         }
+
+        let sigint = DispatchSource.makeSignalSource(signal: SIGINT, queue: .main)
+        sigint.setEventHandler(handler: shutDown)
         sigint.resume()
         signal(SIGINT, SIG_IGN)
 
+        let sigterm = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .main)
+        sigterm.setEventHandler(handler: shutDown)
+        sigterm.resume()
+        signal(SIGTERM, SIG_IGN)
+
         FileHandle.standardError.write(Data("listening on fn hold · model: \(chosenModel.id) · ^C to quit\n".utf8))
         app.run()
+        NotificationCenter.default.removeObserver(terminationObserver)
     }
 }
 

--- a/Sources/parrot/UI/MenuBarController.swift
+++ b/Sources/parrot/UI/MenuBarController.swift
@@ -17,7 +17,7 @@ final class MenuBarController {
         let menu = NSMenu()
         menu.autoenablesItems = false
 
-        stateLabel = NSMenuItem(title: "idle · hold fn to dictate", action: nil, keyEquivalent: "")
+        stateLabel = NSMenuItem(title: "idle · hold fn or double-tap to lock", action: nil, keyEquivalent: "")
         stateLabel.isEnabled = false
         menu.addItem(stateLabel)
 
@@ -40,11 +40,15 @@ final class MenuBarController {
     }
 
     func setRecording(_ recording: Bool) {
-        stateLabel.title = recording ? "● recording" : "idle · hold fn to dictate"
+        stateLabel.title = recording ? "● recording" : "idle · hold fn or double-tap to lock"
     }
 
     func setTranscribing() {
         stateLabel.title = "transcribing…"
+    }
+
+    func setLockedRecording() {
+        stateLabel.title = "🔒 recording · tap fn to stop"
     }
 
     private func configureButton(recording: Bool) {

--- a/Sources/parrot/UI/RecordingOverlay.swift
+++ b/Sources/parrot/UI/RecordingOverlay.swift
@@ -8,13 +8,17 @@ final class RecordingOverlay {
     enum State: Equatable {
         case hidden
         case recording
+        case locked
         case transcribing
     }
 
     private var window: NSPanel?
+    private var pendingHide: DispatchWorkItem?
     private let model = OverlayModel()
 
     func show(_ state: State) {
+        pendingHide?.cancel()
+        pendingHide = nil
         ensureWindow()
         if state == .recording {
             model.resetLevels()
@@ -35,13 +39,17 @@ final class RecordingOverlay {
     }
 
     func hide() {
+        pendingHide?.cancel()
         model.state = .hidden
         // Let the SwiftUI scale+fade animation play out before yanking the
         // window — otherwise it just pops away.
         let window = self.window
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.18) {
+        let workItem = DispatchWorkItem { [weak self] in
             window?.orderOut(nil)
+            self?.pendingHide = nil
         }
+        pendingHide = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.18, execute: workItem)
     }
 
     /// Push a new audio level (0…~1). Safe to call from any thread.
@@ -54,7 +62,7 @@ final class RecordingOverlay {
     private func ensureWindow() {
         if window != nil { return }
         let panel = NSPanel(
-            contentRect: NSRect(x: 0, y: 0, width: 96, height: 44),
+            contentRect: NSRect(x: 0, y: 0, width: 112, height: 44),
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
@@ -137,6 +145,15 @@ private struct OverlayPill: View {
         case .hidden, .recording:
             Waveform(levels: model.levels)
                 .frame(width: 54, height: 22)
+        case .locked:
+            HStack(spacing: 7) {
+                Image(systemName: "lock.fill")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(Color(red: 181/255.0, green: 209/255.0, blue: 255/255.0))
+                Waveform(levels: model.levels)
+                    .frame(width: 54, height: 22)
+            }
+            .frame(width: 72, height: 22)
         case .transcribing:
             ProgressView()
                 .controlSize(.small)

--- a/Tests/parrotTests/FnDictationGestureTests.swift
+++ b/Tests/parrotTests/FnDictationGestureTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import parrot
+
+final class FnDictationGestureTests: XCTestCase {
+    func testLongPressKeepsPushToTalkBehavior() {
+        var gesture = FnDictationGesture()
+
+        XCTAssertEqual(gesture.handle(.pressed(at: 1.0)), [.startRecording])
+        XCTAssertEqual(gesture.handle(.released(at: 2.0)), [.stopRecording])
+        XCTAssertFalse(gesture.isLocked)
+    }
+
+    func testSingleQuickTapStopsAfterDoubleTapWindowExpires() {
+        var gesture = FnDictationGesture(doubleTapInterval: 0.4)
+
+        XCTAssertEqual(gesture.handle(.pressed(at: 1.0)), [.startRecording])
+        XCTAssertEqual(
+            gesture.handle(.released(at: 1.1)),
+            [.scheduleSecondTapTimeout(after: 0.4)]
+        )
+        XCTAssertEqual(gesture.handle(.secondTapTimedOut), [.stopRecording])
+        XCTAssertFalse(gesture.isLocked)
+    }
+
+    func testDoubleTapLocksThenNextPressStops() {
+        var gesture = FnDictationGesture(doubleTapInterval: 0.4)
+
+        XCTAssertEqual(gesture.handle(.pressed(at: 1.0)), [.startRecording])
+        _ = gesture.handle(.released(at: 1.1))
+        XCTAssertEqual(
+            gesture.handle(.pressed(at: 1.2)),
+            [.cancelSecondTapTimeout]
+        )
+        XCTAssertFalse(gesture.isLocked)
+        XCTAssertEqual(gesture.handle(.released(at: 1.25)), [.showLocked])
+        XCTAssertTrue(gesture.isLocked)
+        XCTAssertEqual(gesture.handle(.secondTapTimedOut), [])
+        XCTAssertEqual(gesture.handle(.pressed(at: 3.0)), [])
+        XCTAssertTrue(gesture.isLocked)
+        XCTAssertEqual(gesture.handle(.released(at: 3.1)), [.stopRecording])
+        XCTAssertFalse(gesture.isLocked)
+    }
+
+    func testLongSecondPressFinishesInsteadOfLocking() {
+        var gesture = FnDictationGesture()
+
+        _ = gesture.handle(.pressed(at: 1.0))
+        _ = gesture.handle(.released(at: 1.1))
+        XCTAssertEqual(gesture.handle(.pressed(at: 1.2)), [.cancelSecondTapTimeout])
+        XCTAssertEqual(gesture.handle(.released(at: 2.0)), [.stopRecording])
+        XCTAssertFalse(gesture.isLocked)
+    }
+
+    func testDuplicateEdgesDoNotStartOrStopTwice() {
+        var gesture = FnDictationGesture()
+
+        XCTAssertEqual(gesture.handle(.pressed(at: 1.0)), [.startRecording])
+        XCTAssertEqual(gesture.handle(.pressed(at: 1.1)), [])
+        XCTAssertEqual(gesture.handle(.released(at: 2.0)), [.stopRecording])
+        XCTAssertEqual(gesture.handle(.released(at: 2.1)), [])
+    }
+}


### PR DESCRIPTION
## Summary

Adds an opt-in hands-free dictation flow while preserving the existing hold-to-talk behavior.

- Double-tap `fn` to keep recording after release.
- Tap `fn` once more to stop a locked recording.
- Show a lock next to the recording waveform while locked.
- Add optional `--mute-output` to silence the current output route while recording, then restore its prior mute or volume state.
- Recover cleanly if the event tap is interrupted, or the process receives SIGINT/SIGTERM.

## Implementation

The gesture recognition is a small, testable state machine separate from audio capture and UI. The output mute controller uses current `AudioObject` APIs and is deliberately opt-in so existing users keep today’s audio behavior.

## Validation

- `swift test` — 5 gesture tests passed.
- `git diff --check` passed.
- No app bundle, signing identity, certificate, downloaded model, dictionary data, icon, or other user-specific files are included.

## Coordination

This overlaps with [#4](https://github.com/digimata/parrot/pull/4) in `HotkeyMonitor` and part of `RecordingOverlay`. If #4 lands first, I can rebase this PR and retain only the locked-dictation/audio-specific changes.

## Contribution terms

The repository does not currently declare a LICENSE. I am offering these changes to the repository maintainer for review; a project license or contribution policy would make the intended redistribution terms explicit.