### PR TITLE
Add a persistent, menu-configurable push-to-talk key

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ parrot --hotkey right-option           # change the push-to-talk key
 parrot --no-overlay                    # disable the bottom-of-screen pill
 ```
 
+You can also change the push-to-talk key while Parrot is running: click its
+menu-bar icon, open **Push-to-talk key**, and choose a modifier. The selection
+is applied immediately and remembered for future launches.
+
 ## Stack
 
 - **Swift** — single SPM executable target

--- a/Sources/parrot/Doctor.swift
+++ b/Sources/parrot/Doctor.swift
@@ -16,12 +16,15 @@ struct Check {
 }
 
 enum DoctorReport {
-    static func run() -> [Check] {
-        [
+    static func run(checkFnMapping: Bool = true) -> [Check] {
+        var checks = [
             checkMicrophone(),
             checkAccessibility(),
-            checkFnKeyMapping(),
         ]
+        if checkFnMapping {
+            checks.append(checkFnKeyMapping())
+        }
+        return checks
     }
 
     static func checkMicrophone() -> Check {

--- a/Sources/parrot/Input/HotkeyMonitor.swift
+++ b/Sources/parrot/Input/HotkeyMonitor.swift
@@ -10,17 +10,71 @@ final class HotkeyMonitor {
     enum Event { case pressed, released }
     enum HotkeyError: Error { case tapCreateFailed }
 
-    /// Mask of the modifier we treat as the hotkey. Fn = `.maskSecondaryFn`.
-    private let mask: CGEventFlags
+    enum Hotkey: String, CaseIterable {
+        case fn
+        case leftOption = "left-option"
+        case rightOption = "right-option"
+        case leftCommand = "left-command"
+        case rightCommand = "right-command"
+        case leftControl = "left-control"
+        case rightControl = "right-control"
+        case leftShift = "left-shift"
+        case rightShift = "right-shift"
+
+        var displayName: String {
+            switch self {
+            case .fn: return "Fn"
+            case .leftOption: return "Left Option (⌥)"
+            case .rightOption: return "Right Option (⌥)"
+            case .leftCommand: return "Left Command (⌘)"
+            case .rightCommand: return "Right Command (⌘)"
+            case .leftControl: return "Left Control (⌃)"
+            case .rightControl: return "Right Control (⌃)"
+            case .leftShift: return "Left Shift (⇧)"
+            case .rightShift: return "Right Shift (⇧)"
+            }
+        }
+
+        fileprivate var mask: CGEventFlags {
+            switch self {
+            case .fn: return .maskSecondaryFn
+            case .leftOption, .rightOption: return .maskAlternate
+            case .leftCommand, .rightCommand: return .maskCommand
+            case .leftControl, .rightControl: return .maskControl
+            case .leftShift, .rightShift: return .maskShift
+            }
+        }
+
+        fileprivate var keycode: Int64? {
+            switch self {
+            case .fn: return nil
+            case .leftOption: return 58
+            case .rightOption: return 61
+            case .leftCommand: return 55
+            case .rightCommand: return 54
+            case .leftControl: return 59
+            case .rightControl: return 62
+            case .leftShift: return 56
+            case .rightShift: return 60
+            }
+        }
+    }
+
+    private(set) var hotkey: Hotkey
     private let debug: Bool
     private var onEvent: ((Event) -> Void)?
     private var tap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
     private var isPressed = false
 
-    init(mask: CGEventFlags = .maskSecondaryFn, debug: Bool = false) {
-        self.mask = mask
+    init(hotkey: Hotkey = .fn, debug: Bool = false) {
+        self.hotkey = hotkey
         self.debug = debug
+    }
+
+    func setHotkey(_ hotkey: Hotkey) {
+        self.hotkey = hotkey
+        isPressed = false
     }
 
     func start(onEvent: @escaping (Event) -> Void) throws {
@@ -87,7 +141,11 @@ final class HotkeyMonitor {
                 ))
         }
         guard type == .flagsChanged else { return }
-        let pressed = event.flags.contains(mask)
+        if let expectedKeycode = hotkey.keycode {
+            let keycode = event.getIntegerValueField(.keyboardEventKeycode)
+            guard keycode == expectedKeycode else { return }
+        }
+        let pressed = event.flags.contains(hotkey.mask)
         guard pressed != isPressed else { return }
         isPressed = pressed
         onEvent?(pressed ? .pressed : .released)

--- a/Sources/parrot/Input/HotkeyPreferences.swift
+++ b/Sources/parrot/Input/HotkeyPreferences.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+enum HotkeyPreferences {
+    private static let key = "pushToTalkHotkey"
+
+    static var selected: HotkeyMonitor.Hotkey {
+        get {
+            guard
+                let rawValue = UserDefaults.standard.string(forKey: key),
+                let hotkey = HotkeyMonitor.Hotkey(rawValue: rawValue)
+            else { return .fn }
+            return hotkey
+        }
+        set {
+            UserDefaults.standard.set(newValue.rawValue, forKey: key)
+        }
+    }
+}

--- a/Sources/parrot/Parrot.swift
+++ b/Sources/parrot/Parrot.swift
@@ -34,9 +34,20 @@ struct Run: ParsableCommand {
     @Option(name: .long, help: "Model id to use. Defaults to the recommended model.")
     var model: String?
 
+    @Option(
+        name: .long,
+        help: "Push-to-talk key. Options: \(HotkeyMonitor.Hotkey.allCases.map(\.rawValue).joined(separator: ", "))."
+    )
+    var hotkey: HotkeyMonitor.Hotkey?
+
     func run() throws {
+        let selectedHotkey = hotkey ?? HotkeyPreferences.selected
+        if let hotkey {
+            HotkeyPreferences.selected = hotkey
+        }
+
         if !skipDoctor {
-            let checks = DoctorReport.run()
+            let checks = DoctorReport.run(checkFnMapping: selectedHotkey == .fn)
             if !DoctorReport.allOK(checks) {
                 FileHandle.standardError.write(Data("startup checks failed:\n".utf8))
                 DoctorReport.print(checks)
@@ -81,14 +92,18 @@ struct Run: ParsableCommand {
         let app = NSApplication.shared
         app.setActivationPolicy(.accessory)
 
-        let monitor = HotkeyMonitor(debug: debugHotkey)
+        let monitor = HotkeyMonitor(hotkey: selectedHotkey, debug: debugHotkey)
         let capture = AudioCapture()
         let dumpWav = self.dumpWav
         let overlay: RecordingOverlay? = noOverlay ? nil : MainActor.assumeIsolated { RecordingOverlay() }
         if let overlay {
             capture.onLevel = { level in overlay.pushLevel(level) }
         }
-        let menuBar = MainActor.assumeIsolated { MenuBarController(modelID: chosenModel.id) }
+        let menuBar = MainActor.assumeIsolated {
+            MenuBarController(modelID: chosenModel.id, hotkey: selectedHotkey) {
+                monitor.setHotkey($0)
+            }
+        }
 
         do {
             try monitor.start { event in
@@ -169,10 +184,14 @@ struct Run: ParsableCommand {
         sigint.resume()
         signal(SIGINT, SIG_IGN)
 
-        FileHandle.standardError.write(Data("listening on fn hold · model: \(chosenModel.id) · ^C to quit\n".utf8))
+        FileHandle.standardError.write(Data(
+            "listening on \(selectedHotkey.rawValue) hold · model: \(chosenModel.id) · ^C to quit\n".utf8
+        ))
         app.run()
     }
 }
+
+extension HotkeyMonitor.Hotkey: ExpressibleByArgument {}
 
 struct Doctor: ParsableCommand {
     static let configuration = CommandConfiguration(

--- a/Sources/parrot/UI/MenuBarController.swift
+++ b/Sources/parrot/UI/MenuBarController.swift
@@ -9,21 +9,51 @@ final class MenuBarController {
     private let modelLabel: NSMenuItem
     private let stateLabel: NSMenuItem
     private let modelID: String
+    private var hotkey: HotkeyMonitor.Hotkey
+    private let onHotkeyChanged: (HotkeyMonitor.Hotkey) -> Void
 
-    init(modelID: String) {
+    init(
+        modelID: String,
+        hotkey: HotkeyMonitor.Hotkey,
+        onHotkeyChanged: @escaping (HotkeyMonitor.Hotkey) -> Void
+    ) {
         self.modelID = modelID
+        self.hotkey = hotkey
+        self.onHotkeyChanged = onHotkeyChanged
         self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
 
         let menu = NSMenu()
         menu.autoenablesItems = false
 
-        stateLabel = NSMenuItem(title: "idle · hold fn to dictate", action: nil, keyEquivalent: "")
+        stateLabel = NSMenuItem(
+            title: "idle · hold \(hotkey.displayName) to dictate",
+            action: nil,
+            keyEquivalent: ""
+        )
         stateLabel.isEnabled = false
         menu.addItem(stateLabel)
 
         modelLabel = NSMenuItem(title: "model: \(modelID)", action: nil, keyEquivalent: "")
         modelLabel.isEnabled = false
         menu.addItem(modelLabel)
+
+        menu.addItem(.separator())
+
+        let hotkeyMenu = NSMenu()
+        for candidate in HotkeyMonitor.Hotkey.allCases {
+            let item = NSMenuItem(
+                title: candidate.displayName,
+                action: #selector(hotkeyClicked(_:)),
+                keyEquivalent: ""
+            )
+            item.target = self
+            item.representedObject = candidate.rawValue
+            item.state = candidate == hotkey ? .on : .off
+            hotkeyMenu.addItem(item)
+        }
+        let hotkeyItem = NSMenuItem(title: "Push-to-talk key", action: nil, keyEquivalent: "")
+        hotkeyItem.submenu = hotkeyMenu
+        menu.addItem(hotkeyItem)
 
         menu.addItem(.separator())
 
@@ -40,7 +70,9 @@ final class MenuBarController {
     }
 
     func setRecording(_ recording: Bool) {
-        stateLabel.title = recording ? "● recording" : "idle · hold fn to dictate"
+        stateLabel.title = recording
+            ? "● recording"
+            : "idle · hold \(hotkey.displayName) to dictate"
     }
 
     func setTranscribing() {
@@ -80,5 +112,21 @@ final class MenuBarController {
 
     @objc private func quitClicked() {
         NSApp.terminate(nil)
+    }
+
+    @objc private func hotkeyClicked(_ sender: NSMenuItem) {
+        guard
+            let rawValue = sender.representedObject as? String,
+            let selected = HotkeyMonitor.Hotkey(rawValue: rawValue)
+        else { return }
+
+        hotkey = selected
+        HotkeyPreferences.selected = selected
+        onHotkeyChanged(selected)
+        stateLabel.title = "idle · hold \(selected.displayName) to dictate"
+
+        for item in sender.menu?.items ?? [] {
+            item.state = item === sender ? .on : .off
+        }
     }
 }


### PR DESCRIPTION
Slop warning, vibecoded PR using 5.6 Sol. Feel free to close but I think it can be useful

--- everything from here down is AI generated ---

Third-party keyboards such as Logitech models commonly handle Fn entirely in firmware, so macOS never receives the event Parrot currently requires. This makes the daemon appear to run normally while push-to-talk can never start. The README advertises a hotkey override, but the corresponding CLI option was not implemented.

This adds a checked Push-to-talk key submenu to the menu-bar UI with left/right Option, Command, Control, and Shift alternatives. Selections take effect immediately, persist through UserDefaults, and can also be set with the documented `--hotkey` option. Left/right modifiers are distinguished by hardware keycode because each pair shares a CGEvent flag, and the Fn-specific doctor check is skipped when Fn is not selected.

<img width="557" height="330" alt="Push-to-talk key menu" src="https://github.com/user-attachments/assets/75d525d3-c1ea-47f9-bf93-577858c37a3d" />
