### PR TITLE
Fix three privacy and supply-chain issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,12 @@ on:
       - "v*"
   workflow_dispatch:
 
+# A permissions block replaces the defaults rather than merging with them, so
+# contents: write must stay listed or the release upload fails with a 403.
 permissions:
   contents: write
+  id-token: write      # OIDC token used to sign the attestation
+  attestations: write
 
 jobs:
   build:
@@ -49,6 +53,14 @@ jobs:
           tar -czf parrot-macos-arm64.tar.gz parrot
           shasum -a 256 parrot-macos-arm64.tar.gz > parrot-macos-arm64.tar.gz.sha256
           ls -lh
+
+      # Attests the file's digest, so it must run on the final bytes: after
+      # packaging, before upload.
+      - name: attest build provenance
+        uses: actions/attest-build-provenance@v4
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          subject-path: dist/parrot-macos-arm64.tar.gz
 
       - name: release
         uses: softprops/action-gh-release@v2

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ parrot                                 # run in the foreground (^C to quit)
 parrot setup                           # one-time setup: permissions + model download
 parrot install --launch-at-login       # register a LaunchAgent (background daemon)
 parrot install --uninstall             # remove the LaunchAgent
+parrot install --purge-legacy-logs     # delete world-readable /tmp logs from older versions
 parrot doctor                          # check permissions + fn key setting
 parrot models list                     # list available models
 parrot models download <id>            # pre-download a model
@@ -39,6 +40,24 @@ parrot --model whisper-large-v3-turbo  # bigger, multilingual, slower first-run
 parrot --hotkey right-option           # change the push-to-talk key
 parrot --no-overlay                    # disable the bottom-of-screen pill
 ```
+
+## Privacy
+
+Transcripts are never written to disk. The daemon logs timing and length only
+(`→ 0.42s · 63 chars`); `--echo-transcripts` prints the full text to stderr, and its
+help text says so, but it is never used by the LaunchAgent.
+
+`parrot install --launch-at-login` discards the daemon's output. To keep it, add
+`--log-file` and it goes to `~/Library/Logs/parrot.log`, created `0600` and owned by you.
+Either way the log holds no transcript text.
+
+> **If you installed parrot before this change**, the daemon was writing every transcript
+> in plaintext to `/tmp/parrot.err.log`, which any local user can read, with no rotation
+> and no size cap. `parrot doctor` will flag the file if it's still there. Read it, then
+> remove it with `parrot install --purge-legacy-logs`.
+
+`--dump-wav` writes raw recorded audio to `~/Library/Caches/parrot/last-capture.wav`
+(`0600`, in a `0700` directory).
 
 ## Stack
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,42 @@ parrot install --launch-at-login   # optional — runs in the background on logi
 
 **Requires:** macOS 14+ on Apple Silicon (M1 or newer). Transcription runs on the Apple Neural Engine via CoreML — so the installer refuses to run on Intel.
 
-The installer drops the binary in `/usr/local/bin/parrot`. Builds are unsigned for now, so the installer strips the quarantine xattr — once you've inspected the script you'll see exactly what it does.
+The installer drops the binary in `/usr/local/bin/parrot`. It downloads the published
+`.sha256` and verifies the tarball before extracting it, prints the digest, and refuses to
+install if the checksum is missing or doesn't match. It also checks the archive contains
+exactly one member (`parrot`) and no absolute or `..` paths.
+
+Pin a version — piping to `sh` leaves no way to pass arguments, so use the environment:
+
+```sh
+PARROT_VERSION=v0.0.5 curl -fsSL https://digimata.github.io/parrot/install.sh | sh
+```
+
+**Builds are unsigned and un-notarized.** The installer removes the quarantine attribute
+if one is present, but `curl` does not set it — quarantine is applied by apps that opt into
+`LSFileQuarantineEnabled`, like browsers — so in the piped path there is nothing to remove
+and the script says so. It matters only if you downloaded the tarball in a browser.
+
+### Verifying a release by hand
+
+```sh
+TAG=v0.0.5
+curl -fsSLO https://github.com/digimata/parrot/releases/download/$TAG/parrot-macos-arm64.tar.gz
+curl -fsSLO https://github.com/digimata/parrot/releases/download/$TAG/parrot-macos-arm64.tar.gz.sha256
+shasum -a 256 -c parrot-macos-arm64.tar.gz.sha256
+
+# releases built after provenance was enabled can also be checked against GitHub's
+# signed attestation (requires the gh CLI, logged in):
+gh attestation verify parrot-macos-arm64.tar.gz --repo digimata/parrot
+```
+
+A checksum published in the same release as the artifact only proves the download wasn't
+corrupted in transit — whoever can replace the tarball can replace the `.sha256` beside it.
+The attestation is the stronger check: GitHub signs a statement binding the artifact to a
+specific workflow run at a specific commit, which the repo owner cannot forge. Releases
+published before provenance was enabled have no attestation, so the installer reports a
+failed provenance check as a warning rather than aborting. Set
+`PARROT_REQUIRE_ATTESTATION=1` to make it abort instead.
 
 ## How to use
 

--- a/Sources/parrot/Doctor.swift
+++ b/Sources/parrot/Doctor.swift
@@ -21,7 +21,23 @@ enum DoctorReport {
             checkMicrophone(),
             checkAccessibility(),
             checkFnKeyMapping(),
+            checkLegacyLogs(),
         ]
+    }
+
+    /// Versions up to v0.0.5 sent the daemon's stderr, which included every
+    /// transcript, to world-readable paths in /tmp.
+    static func checkLegacyLogs() -> Check {
+        let paths = ["/tmp/parrot.out.log", "/tmp/parrot.err.log"]
+        let found = paths.filter { FileManager.default.fileExists(atPath: $0) }
+        guard !found.isEmpty else {
+            return Check(name: "legacy logs", status: .ok, remediation: nil)
+        }
+        return Check(
+            name: "legacy logs",
+            status: .warn("world-readable transcript logs present: \(found.joined(separator: ", "))"),
+            remediation: "review them, then run `parrot install --purge-legacy-logs`"
+        )
     }
 
     static func checkMicrophone() -> Check {

--- a/Sources/parrot/Input/HotkeyMonitor.swift
+++ b/Sources/parrot/Input/HotkeyMonitor.swift
@@ -35,10 +35,9 @@ final class HotkeyMonitor {
             throw HotkeyError.tapCreateFailed
         }
 
-        let mask: CGEventMask =
-            (1 << CGEventType.flagsChanged.rawValue)
-            | (1 << CGEventType.keyDown.rawValue)
-            | (1 << CGEventType.keyUp.rawValue)
+        // Deliberately narrowed: adding keyDown/keyUp would hand this process
+        // the content of every keystroke typed system-wide. Don't widen it.
+        let mask: CGEventMask = (1 << CGEventType.flagsChanged.rawValue)
         let userInfo = Unmanaged.passUnretained(self).toOpaque()
 
         // .cgSessionEventTap is the right level for an accessibility-granted
@@ -76,21 +75,27 @@ final class HotkeyMonitor {
         onEvent = nil
     }
 
-    fileprivate func handle(type: CGEventType, event: CGEvent) {
+    fileprivate func handle(event: CGEvent) {
         if debug {
-            let flags = event.flags
-            let keycode = event.getIntegerValueField(.keyboardEventKeycode)
+            // No keycode: it's meaningless for flagsChanged anyway.
             FileHandle.standardError.write(
-                Data(
-                    "  [debug] type=\(type.rawValue) keycode=\(keycode) flags=\(String(flags.rawValue, radix: 16))\n"
-                        .utf8
-                ))
+                Data("  [debug] flags=\(String(event.flags.rawValue, radix: 16))\n".utf8)
+            )
         }
-        guard type == .flagsChanged else { return }
         let pressed = event.flags.contains(mask)
         guard pressed != isPressed else { return }
         isPressed = pressed
         onEvent?(pressed ? .pressed : .released)
+    }
+
+    /// macOS disables taps that block too long, and whenever Secure Input is
+    /// engaged. Without this the hotkey silently stops working for the session.
+    fileprivate func reEnableTap() {
+        guard let tap else { return }
+        CGEvent.tapEnable(tap: tap, enable: true)
+        FileHandle.standardError.write(Data(
+            "hotkey tap was disabled by the system; re-enabled\n".utf8
+        ))
     }
 }
 
@@ -103,16 +108,16 @@ private func hotkeyCallback(
     guard let userInfo else { return Unmanaged.passUnretained(event) }
     let monitor = Unmanaged<HotkeyMonitor>.fromOpaque(userInfo).takeUnretainedValue()
 
+    // These two are delivered out of band, regardless of eventsOfInterest.
     if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-        // System disabled our tap; we'll need to re-enable. For now just no-op
-        // and let the user restart parrot.
+        monitor.reEnableTap()
         return Unmanaged.passUnretained(event)
     }
 
     let copy = event.copy()
     DispatchQueue.main.async {
         if let copy {
-            monitor.handle(type: type, event: copy)
+            monitor.handle(event: copy)
         }
     }
     return Unmanaged.passUnretained(event)

--- a/Sources/parrot/Install.swift
+++ b/Sources/parrot/Install.swift
@@ -17,17 +17,34 @@ struct Install: ParsableCommand {
     @Flag(name: .long, help: "Remove the launch-at-login agent.")
     var uninstall: Bool = false
 
+    @Flag(name: .long, help: "Keep daemon output in ~/Library/Logs/parrot.log (mode 0600). Off by default; output is discarded.")
+    var logFile: Bool = false
+
+    @Flag(name: .long, help: "Delete the world-readable /tmp/parrot.{out,err}.log files left by earlier versions.")
+    var purgeLegacyLogs: Bool = false
+
     func run() throws {
-        if launchAtLogin == uninstall {
+        if launchAtLogin && uninstall {
+            FileHandle.standardError.write(Data(
+                "specify exactly one of --launch-at-login or --uninstall\n".utf8
+            ))
+            throw ExitCode(64)
+        }
+        if !launchAtLogin && !uninstall && !purgeLegacyLogs {
             FileHandle.standardError.write(Data(
                 "specify exactly one of --launch-at-login or --uninstall\n".utf8
             ))
             throw ExitCode(64)
         }
 
+        reportLegacyLogs()
+        if purgeLegacyLogs {
+            purgeLegacyLogFiles()
+        }
+
         if uninstall {
             try removeAgent()
-        } else {
+        } else if launchAtLogin {
             try writeAgent()
         }
     }
@@ -46,15 +63,30 @@ struct Install: ParsableCommand {
     private func writeAgent() throws {
         let binary = try resolveBinaryPath()
 
-        let plist: [String: Any] = [
+        let logPath: String
+        if logFile {
+            logPath = try prepareLogFile()
+        } else {
+            logPath = "/dev/null"
+        }
+
+        // ProgramArguments deliberately omits --echo-transcripts: a background
+        // daemon must never be configured to write transcript text to a log.
+        var plist: [String: Any] = [
             "Label": Self.label,
             "ProgramArguments": [binary, "run", "--skip-doctor"],
             "RunAtLoad": true,
             "KeepAlive": ["SuccessfulExit": false] as [String: Any],
             "ProcessType": "Interactive",
-            "StandardOutPath": "/tmp/parrot.out.log",
-            "StandardErrorPath": "/tmp/parrot.err.log",
+            "StandardOutPath": logPath,
+            "StandardErrorPath": logPath,
         ]
+        if logFile {
+            // launchd recreates a missing std-path file under its own umask
+            // (0644), so the 0600 degrades the first time the log is deleted.
+            // plists can't encode octal: 127 is 0o177.
+            plist["Umask"] = 127
+        }
 
         let url = plistURL
         try FileManager.default.createDirectory(
@@ -80,7 +112,78 @@ struct Install: ParsableCommand {
         print("✓ launch-at-login installed")
         print("  plist:  \(url.path)")
         print("  binary: \(binary)")
-        print("  logs:   /tmp/parrot.out.log, /tmp/parrot.err.log")
+        if logFile {
+            print("  logs:   \(logPath) (mode 0600)")
+        } else {
+            print("  logs:   discarded — pass --log-file to keep them")
+        }
+    }
+
+    /// launchd appends to an existing std-path file and leaves its mode alone,
+    /// but creates a missing one at 0644 — so create it 0600 before bootstrap.
+    private func prepareLogFile() throws -> String {
+        let fm = FileManager.default
+        let url = fm.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Logs", isDirectory: true)
+            .appendingPathComponent("parrot.log")
+        try fm.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        if fm.fileExists(atPath: url.path) {
+            try fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+        } else {
+            _ = fm.createFile(
+                atPath: url.path,
+                contents: nil,
+                attributes: [.posixPermissions: 0o600]
+            )
+        }
+        return url.path
+    }
+
+    private static let legacyLogPaths = ["/tmp/parrot.out.log", "/tmp/parrot.err.log"]
+
+    /// Versions up to v0.0.5 pointed the daemon's stderr at /tmp and logged
+    /// every transcript, so anyone who ran `--launch-at-login` has a plaintext
+    /// record of everything they dictated, readable by any local user.
+    private func reportLegacyLogs() {
+        let fm = FileManager.default
+        let found = Self.legacyLogPaths.filter { fm.fileExists(atPath: $0) }
+        guard !found.isEmpty else { return }
+
+        var msg = "\n⚠️  found logs from an earlier parrot version:\n"
+        for path in found {
+            let attrs = try? fm.attributesOfItem(atPath: path)
+            let size = (attrs?[.size] as? NSNumber)?.intValue ?? 0
+            msg += "     \(path) — \(size) bytes\n"
+        }
+        msg += "   these are world-readable and contain the text of every transcript\n"
+        msg += "   parrot produced while the daemon was running.\n"
+        if !purgeLegacyLogs {
+            msg += "   review them, then delete with: parrot install --purge-legacy-logs\n"
+        }
+        msg += "\n"
+        FileHandle.standardError.write(Data(msg.utf8))
+    }
+
+    private func purgeLegacyLogFiles() {
+        let fm = FileManager.default
+        let found = Self.legacyLogPaths.filter { fm.fileExists(atPath: $0) }
+        if found.isEmpty {
+            print("no legacy /tmp logs to remove")
+            return
+        }
+        for path in found {
+            do {
+                try fm.removeItem(atPath: path)
+                print("✓ removed \(path)")
+            } catch {
+                FileHandle.standardError.write(Data(
+                    "couldn't remove \(path): \(error)\n".utf8
+                ))
+            }
+        }
     }
 
     private func removeAgent() throws {

--- a/Sources/parrot/Parrot.swift
+++ b/Sources/parrot/Parrot.swift
@@ -22,7 +22,7 @@ struct Run: ParsableCommand {
     @Flag(name: .long, help: "Skip permission checks at startup.")
     var skipDoctor: Bool = false
 
-    @Flag(name: .long, help: "Print every keyboard event the tap sees (debug).")
+    @Flag(name: .long, help: "Print the modifier flags on each flagsChanged event the tap sees (debug).")
     var debugHotkey: Bool = false
 
     @Flag(name: .long, help: "Write each capture to ~/Library/Caches/parrot/last-capture.wav for inspection. The file holds raw recorded audio.")

--- a/Sources/parrot/Parrot.swift
+++ b/Sources/parrot/Parrot.swift
@@ -25,8 +25,11 @@ struct Run: ParsableCommand {
     @Flag(name: .long, help: "Print every keyboard event the tap sees (debug).")
     var debugHotkey: Bool = false
 
-    @Flag(name: .long, help: "Write each capture to /tmp/parrot-last.wav for inspection.")
+    @Flag(name: .long, help: "Write each capture to ~/Library/Caches/parrot/last-capture.wav for inspection. The file holds raw recorded audio.")
     var dumpWav: Bool = false
+
+    @Flag(name: .long, help: "Print the full transcript text to stderr. The text of everything you dictate will appear in logs.")
+    var echoTranscripts: Bool = false
 
     @Flag(name: .long, help: "Disable the on-screen recording overlay.")
     var noOverlay: Bool = false
@@ -84,6 +87,7 @@ struct Run: ParsableCommand {
         let monitor = HotkeyMonitor(debug: debugHotkey)
         let capture = AudioCapture()
         let dumpWav = self.dumpWav
+        let echoTranscripts = self.echoTranscripts
         let overlay: RecordingOverlay? = noOverlay ? nil : MainActor.assumeIsolated { RecordingOverlay() }
         if let overlay {
             capture.onLevel = { level in overlay.pushLevel(level) }
@@ -116,8 +120,8 @@ struct Run: ParsableCommand {
                         String(format: "○ captured %.2fs · rms %.3f\n", seconds, rms).utf8
                     ))
                     if dumpWav, !samples.isEmpty {
-                        let path = "/tmp/parrot-last.wav"
                         do {
+                            let path = try dumpWavPath()
                             try WAVWriter.write(samples: samples, sampleRate: 16_000, to: path)
                             FileHandle.standardError.write(Data("  wrote \(path)\n".utf8))
                         } catch {
@@ -136,9 +140,10 @@ struct Run: ParsableCommand {
                         do {
                             let text = try await transcriber.transcribe(samples)
                             let elapsed = Date().timeIntervalSince(started)
-                            FileHandle.standardError.write(Data(
-                                String(format: "→ %.2fs · %@\n", elapsed, text).utf8
-                            ))
+                            let line = echoTranscripts
+                                ? String(format: "→ %.2fs · %@\n", elapsed, text)
+                                : String(format: "→ %.2fs · %ld chars\n", elapsed, text.count)
+                            FileHandle.standardError.write(Data(line.utf8))
                             await MainActor.run {
                                 TextInjector.inject(text)
                                 overlay?.hide()
@@ -172,6 +177,26 @@ struct Run: ParsableCommand {
         FileHandle.standardError.write(Data("listening on fn hold · model: \(chosenModel.id) · ^C to quit\n".utf8))
         app.run()
     }
+}
+
+/// Destination for `--dump-wav`. Recorded audio is as sensitive as the
+/// transcript, so it stays out of world-readable /tmp.
+private func dumpWavPath() throws -> String {
+    let fm = FileManager.default
+    let dir = fm.homeDirectoryForCurrentUser
+        .appendingPathComponent("Library/Caches/parrot", isDirectory: true)
+    try fm.createDirectory(
+        at: dir,
+        withIntermediateDirectories: true,
+        attributes: [.posixPermissions: 0o700]
+    )
+    // createDirectory doesn't retighten a directory that already exists.
+    try fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: dir.path)
+
+    let path = dir.appendingPathComponent("last-capture.wav").path
+    // Pre-create 0600; a plain write would land under the process umask (0644).
+    _ = fm.createFile(atPath: path, contents: nil, attributes: [.posixPermissions: 0o600])
+    return path
 }
 
 struct Doctor: ParsableCommand {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,15 +1,21 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # parrot installer.
 #   curl -fsSL https://digimata.github.io/parrot/install.sh | sh
 #
-# Fetches the latest arm64 macOS binary from GitHub Releases, drops it
-# in /usr/local/bin, and strips the quarantine xattr so Gatekeeper doesn't
-# block the unsigned binary.
+# Fetches the latest arm64 macOS binary from GitHub Releases, checks it against
+# the published SHA-256, and drops it in /usr/local/bin.
+#
+# Pin a specific release with PARROT_VERSION (piping to sh leaves no way to pass
+# arguments, so an env var is the only mechanism):
+#   PARROT_VERSION=v0.0.5 curl -fsSL https://digimata.github.io/parrot/install.sh | sh
 #
 # Apple Silicon only — WhisperKit uses the Apple Neural Engine via CoreML,
 # which only ships on M-series chips.
+#
+# POSIX sh only: this is documented as `| sh`, so the shebang above is bypassed
+# in the common path. Don't reintroduce bashisms (`set -o pipefail`, arrays).
 
-set -euo pipefail
+set -eu
 
 REPO="digimata/parrot"
 BIN_NAME="parrot"
@@ -33,34 +39,110 @@ if [ "$ARCH" != "arm64" ]; then
     exit 1
 fi
 
-for cmd in curl tar; do
+for cmd in curl tar shasum; do
     if ! command -v "$cmd" >/dev/null 2>&1; then
         red "missing dependency: $cmd"
         exit 1
     fi
 done
 
-# 2. resolve latest release
-dim "→ resolving latest release..."
-TAG=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
-    | grep -E '"tag_name"' \
-    | head -1 \
-    | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')
-
-if [ -z "${TAG:-}" ]; then
-    red "couldn't determine latest release tag"
-    exit 1
+# 2. resolve release
+if [ -n "${PARROT_VERSION:-}" ]; then
+    TAG="$PARROT_VERSION"
+    dim "→ using pinned release ${TAG} (PARROT_VERSION)"
+else
+    dim "→ resolving latest release..."
+    # Capture the response first rather than piping curl into grep: in a pipeline
+    # the exit status is grep's, so a failed download would slip through.
+    if ! RELEASE_JSON=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest"); then
+        red "couldn't reach the GitHub releases API"
+        exit 1
+    fi
+    TAG=$(printf '%s\n' "$RELEASE_JSON" \
+        | grep -E '"tag_name"' \
+        | head -1 \
+        | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')
+    if [ -z "${TAG:-}" ]; then
+        red "couldn't determine latest release tag"
+        exit 1
+    fi
+    dim "  ${TAG}"
 fi
-dim "  ${TAG}"
 
 URL="https://github.com/${REPO}/releases/download/${TAG}/${ASSET}"
 
-# 3. download + extract
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 
+# 3. download tarball + checksum
 dim "→ downloading ${ASSET}..."
-curl -fsSL "$URL" -o "$TMP/${ASSET}"
+if ! curl -fsSL "$URL" -o "$TMP/${ASSET}"; then
+    red "download failed: ${URL}"
+    red "if you pinned PARROT_VERSION, check that ${TAG} exists and has a ${ASSET} asset."
+    exit 1
+fi
+
+dim "→ downloading ${ASSET}.sha256..."
+if ! curl -fsSL "${URL}.sha256" -o "$TMP/${ASSET}.sha256"; then
+    red "no ${ASSET}.sha256 published for ${TAG} — refusing to install unverified."
+    red "every release ships one, so its absence is itself a reason to stop."
+    exit 1
+fi
+
+# 4. verify checksum BEFORE extracting
+dim "→ verifying checksum..."
+if ! (cd "$TMP" && shasum -a 256 -c "${ASSET}.sha256" >/dev/null 2>&1); then
+    red "CHECKSUM MISMATCH — the download does not match the published SHA-256."
+    red "expected: $(cut -d' ' -f1 <"$TMP/${ASSET}.sha256")"
+    red "actual:   $(shasum -a 256 "$TMP/${ASSET}" | cut -d' ' -f1)"
+    red "refusing to install. this means a corrupted download or a tampered artifact."
+    exit 1
+fi
+DIGEST=$(shasum -a 256 "$TMP/${ASSET}" | cut -d' ' -f1)
+green "✓ sha256 ${DIGEST}"
+
+# 5. build provenance (advisory)
+#
+# Deliberately not fail-closed. `gh attestation verify` requires the user to be
+# logged in even for a public repo, and returns the same exit code for "no
+# attestation exists", "your token expired", and a genuine verification failure
+# (cli/cli#9338) — so blocking on it would break installs for reasons unrelated
+# to tampering. The checksum above is the check that fails closed.
+# PARROT_REQUIRE_ATTESTATION=1 makes any verification failure fatal.
+if command -v gh >/dev/null 2>&1; then
+    dim "→ verifying build provenance..."
+    if gh attestation verify "$TMP/${ASSET}" --repo "${REPO}" >/dev/null 2>&1; then
+        green "✓ provenance verified — built by ${REPO} in GitHub Actions"
+    elif [ -n "${PARROT_REQUIRE_ATTESTATION:-}" ]; then
+        red "provenance verification FAILED and PARROT_REQUIRE_ATTESTATION is set."
+        red "re-run without it, or diagnose with:"
+        red "  gh attestation verify <file> --repo ${REPO}"
+        exit 1
+    else
+        red "note: could not verify build provenance for ${TAG}."
+        red "  this is expected for releases published before attestations were added,"
+        red "  and also happens if gh isn't logged in. it is NOT proof of tampering."
+        red "  the sha256 above still matched. to investigate:"
+        red "    gh attestation verify <file> --repo ${REPO}"
+    fi
+else
+    dim "  gh not installed — skipping provenance check. to verify by hand later:"
+    dim "    gh attestation verify ${ASSET} --repo ${REPO}"
+fi
+
+# 6. inspect the archive BEFORE extracting
+dim "→ inspecting archive..."
+MEMBERS=$(tar -tzf "$TMP/${ASSET}")
+if printf '%s\n' "$MEMBERS" | grep -qE '^/|(^|/)\.\.(/|$)'; then
+    red "archive contains an absolute or parent-relative path — refusing to extract:"
+    printf '%s\n' "$MEMBERS" >&2
+    exit 1
+fi
+if [ "$MEMBERS" != "$BIN_NAME" ]; then
+    red "archive should contain exactly one member (${BIN_NAME}), got:"
+    printf '%s\n' "$MEMBERS" >&2
+    exit 1
+fi
 
 dim "→ extracting..."
 tar -xzf "$TMP/${ASSET}" -C "$TMP"
@@ -72,10 +154,19 @@ fi
 
 chmod +x "$TMP/${BIN_NAME}"
 
-# 4. strip quarantine so Gatekeeper lets the unsigned binary run
-xattr -d com.apple.quarantine "$TMP/${BIN_NAME}" 2>/dev/null || true
+# 7. quarantine
+#
+# curl does not set com.apple.quarantine — it's applied by apps that opt into
+# LSFileQuarantineEnabled (browsers, Mail). This is a no-op in the `curl | sh`
+# path, and only does anything for a tarball downloaded via a browser.
+if xattr -p com.apple.quarantine "$TMP/${BIN_NAME}" >/dev/null 2>&1; then
+    dim "→ removing com.apple.quarantine (the archive was downloaded by a quarantining app)"
+    xattr -d com.apple.quarantine "$TMP/${BIN_NAME}" 2>/dev/null || true
+else
+    dim "  no quarantine attribute to remove"
+fi
 
-# 5. install
+# 8. install
 SUDO=""
 if [ ! -w "$INSTALL_DIR" ]; then
     if [ ! -d "$INSTALL_DIR" ]; then


### PR DESCRIPTION
Three independent fixes, one per commit, so they can be reviewed or cherry-picked separately. The first one is the urgent one.

## 1. Transcripts were being written to a world-readable log, permanently

`Install.swift` pointed the LaunchAgent's `StandardErrorPath` at `/tmp/parrot.err.log`, and `Parrot.swift` logged the full text of every completed transcription to stderr. **Anyone who ran `parrot install --launch-at-login` has a plaintext record of every sentence they have ever dictated, in a world-readable directory, with no rotation and no size cap.** This is worth telling existing users about directly.

- Transcript line now records timing and length only (`→ 0.42s · 63 chars`)
- New `--echo-transcripts` restores the full text; its help says the text will appear in logs
- It is deliberately **not** forwarded into the LaunchAgent's `ProgramArguments`, so the daemon can never be configured to log transcript text
- Generated plist now points both `StandardOutPath` and `StandardErrorPath` at `/dev/null`
- New `parrot install --log-file` opts into `~/Library/Logs/parrot.log`, created `0600` before `launchctl bootstrap`
- Plist also sets `Umask` 127 — launchd recreates a missing std-path file at `0644`, so without it the `0600` silently degrades the first time the log is deleted
- `parrot install` now warns about pre-existing `/tmp/parrot.{out,err}.log`, naming each path and its size. Never deletes silently; `parrot install --purge-legacy-logs` does that, and works standalone
- `parrot doctor` gains a legacy-logs check
- `--dump-wav` had the same bug at smaller scale (raw mic audio to `/tmp/parrot-last.wav`); now `~/Library/Caches/parrot/last-capture.wav` at `0600` in a `0700` directory

## 2. The event tap subscribed to far more than it needed

The tap requested `keyDown` and `keyUp` alongside `flagsChanged`, then discarded everything but `flagsChanged` one line later. It was `.listenOnly` and nothing was done with the events, but `--debug-hotkey` printed the keycode of every event it saw.

- `eventsOfInterest` is now `flagsChanged` only, with a comment so it doesn't get widened back
- Removed the now-unreachable `guard type == .flagsChanged` and the parameter that existed only to serve it
- Debug output prints the raw flags bitmask and no longer reads `keyboardEventKeycode`
- `--debug-hotkey`'s help no longer promises "every keyboard event the tap sees"
- **Related bug, same file:** `.tapDisabledByTimeout` / `.tapDisabledByUserInput` were handled by doing nothing, so the daemon could silently stop responding to the hotkey. Both now re-enable the tap and log a line

One thing to weigh: Secure Input engages on password fields, which a dictation daemon sits beside constantly, and a bare re-enable won't stick while it's active. Rate-limiting was left out to keep the diff scoped — happy to add it if you'd prefer.

## 3. The installer verified nothing it downloaded

`scripts/install.sh` resolved the latest tag, downloaded, extracted and installed with no integrity check, even though `release.yml` has always uploaded a `.sha256` that nothing ever fetched.

- Downloads `${ASSET}.sha256` and verifies with `shasum -a 256 -c` **before** extracting; prints the digest; fails closed on mismatch or a missing checksum, with no unverified fallback
- Inspects the archive with `tar -tzf` first, rejecting anything that isn't exactly the member `parrot`, or that has an absolute or `..` path
- `PARROT_VERSION` pins an exact tag (piping to `sh` leaves no way to pass arguments)
- The blanket `xattr -d com.apple.quarantine` was a **no-op** — `curl` doesn't set that attribute; it's applied by apps opting into `LSFileQuarantineEnabled`. It now reports whether there was anything to remove
- Made POSIX-clean so the documented `| sh` is honest: dropped `set -o pipefail`, and the tag lookup no longer pipes `curl` into `grep`, where a failed download was masked by grep's exit status. Keeps the `| sh` one-liner valid, so `gh-pages/index.html` needs no change
- `release.yml` adds `actions/attest-build-provenance` with `id-token` / `attestations` write. Note `permissions:` **replaces** rather than merges, so `contents: write` is re-declared — without that the release upload would start failing with a 403

**On the honest limit:** a checksum published in the same release as the artifact does not make the install trustworthy. It proves the download wasn't corrupted; whoever can replace the tarball can replace the `.sha256` beside it. The attestation is the part that actually helps.

**Why provenance is advisory rather than fail-closed:** `gh attestation verify` requires the user to be logged in even for a public repo, and returns the same exit code for "no attestation exists", "your token expired", and a genuine verification failure ([cli/cli#9338](https://github.com/cli/cli/issues/9338)). No release before this change has an attestation, and v0.0.5 can never retroactively get one — so failing closed would make parrot uninstallable today for everyone who has `gh` installed. The checksum is the check that blocks. `PARROT_REQUIRE_ATTESTATION=1` makes provenance failures fatal too.

## Two things that need you

- **`gh-pages` must be updated together.** `scripts/install.sh` and the copy served at `digimata.github.io/parrot/install.sh` are currently byte-identical (`2ca5a0b6…a936ee`). I can't push to `gh-pages`, so this PR only changes the copy on `master`.
- **Commit 2 will likely conflict** with #4 and #7, which both rewrite hotkey handling.

## Verified / not verified

Tested: fresh install writes `/dev/null` for both path keys; `--log-file` produces `-rw-------`; doctor warns with a legacy log present and passes without one; `--purge-legacy-logs` exits 0 standalone (it previously hit the "specify exactly one of" guard and exited 64). Installer, against both a local server and the real v0.0.5 release: a tampered tarball, a missing `.sha256`, and an archive with an extra member each exit 1 with nothing installed; `PARROT_VERSION=v0.0.5` installs that tag and its digest matches the published one. All three commits build independently with `swift build -c release`.

Not tested: the Fn press/release path with `--debug-hotkey`, which needs Accessibility granted and a physical keypress — the narrowing is verified by inspection instead (no `keyDown`/`keyUp` subscription and no `keyboardEventKeycode` read remain). And the attestation itself can't be exercised until a tag is built by the updated workflow.

One correction to how this is easy to describe: `--debug-hotkey` will still emit a line when you type a capital letter, because Shift is itself a `flagsChanged` event. What's gone is any keycode, and any output for plain character keys.

Nothing under `UI/`, `Transcription/`, or `AudioCapture.swift`'s capture path was touched. No new dependencies.

Unrelated, spotted while working and left alone: `README.md` documents `parrot --hotkey right-option`, but no such flag exists on `Run` — possibly documented ahead of #4/#7.

---

Claude was used heavily for this work.
