### PR TITLE
add --hotkey option to pick the push-to-talk key (fn or right-option)

### DIFF
--- a/Sources/parrot/Input/HotkeyMonitor.swift
+++ b/Sources/parrot/Input/HotkeyMonitor.swift
@@ -12,14 +12,18 @@ final class HotkeyMonitor {
 
     /// Mask of the modifier we treat as the hotkey. Fn = `.maskSecondaryFn`.
     private let mask: CGEventFlags
+    /// When set, only flagsChanged events with this keycode are considered,
+    /// so left/right variants of a modifier can be told apart.
+    private let keycode: Int64?
     private let debug: Bool
     private var onEvent: ((Event) -> Void)?
     private var tap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
     private var isPressed = false
 
-    init(mask: CGEventFlags = .maskSecondaryFn, debug: Bool = false) {
+    init(mask: CGEventFlags = .maskSecondaryFn, keycode: Int64? = nil, debug: Bool = false) {
         self.mask = mask
+        self.keycode = keycode
         self.debug = debug
     }
 
@@ -87,6 +91,7 @@ final class HotkeyMonitor {
                 ))
         }
         guard type == .flagsChanged else { return }
+        if let keycode, event.getIntegerValueField(.keyboardEventKeycode) != keycode { return }
         let pressed = event.flags.contains(mask)
         guard pressed != isPressed else { return }
         isPressed = pressed

--- a/Sources/parrot/Parrot.swift
+++ b/Sources/parrot/Parrot.swift
@@ -34,6 +34,9 @@ struct Run: ParsableCommand {
     @Option(name: .long, help: "Model id to use. Defaults to the recommended model.")
     var model: String?
 
+    @Option(name: .long, help: "Push-to-talk key: fn (default) or right-option.")
+    var hotkey: String = "fn"
+
     func run() throws {
         if !skipDoctor {
             let checks = DoctorReport.run()
@@ -81,7 +84,16 @@ struct Run: ParsableCommand {
         let app = NSApplication.shared
         app.setActivationPolicy(.accessory)
 
-        let monitor = HotkeyMonitor(debug: debugHotkey)
+        let monitor: HotkeyMonitor
+        switch hotkey {
+        case "fn":
+            monitor = HotkeyMonitor(debug: debugHotkey)
+        case "right-option":
+            monitor = HotkeyMonitor(mask: .maskAlternate, keycode: 61, debug: debugHotkey)
+        default:
+            FileHandle.standardError.write(Data("unknown hotkey: \(hotkey) (use fn or right-option)\n".utf8))
+            throw ExitCode(1)
+        }
         let capture = AudioCapture()
         let dumpWav = self.dumpWav
         let overlay: RecordingOverlay? = noOverlay ? nil : MainActor.assumeIsolated { RecordingOverlay() }
@@ -169,7 +181,7 @@ struct Run: ParsableCommand {
         sigint.resume()
         signal(SIGINT, SIG_IGN)
 
-        FileHandle.standardError.write(Data("listening on fn hold · model: \(chosenModel.id) · ^C to quit\n".utf8))
+        FileHandle.standardError.write(Data("listening on \(hotkey) hold · model: \(chosenModel.id) · ^C to quit\n".utf8))
         app.run()
     }
 }


### PR DESCRIPTION
## What

Implements the `--hotkey` run option that the README already documents (`parrot --hotkey right-option`) but the code never wired up: `HotkeyMonitor` was hardcoded to fn.

- `--hotkey fn` (default): unchanged behavior.
- `--hotkey right-option`: watches flagsChanged for the option mask filtered to keycode 61, so the left option key stays free for normal typing.
- Unknown values fail with a clear error.
- The startup line now names the active key.

## Why

On the current macOS 27 developer beta (26A5388g, M1 MacBook Pro), the system stops delivering the bare fn flagsChanged event (keycode 63) to event taps entirely: fn still works as a modifier for other keys, but no standalone press event ever reaches the tap, so hold-fn push-to-talk can never trigger. Verified with an independent event-tap logger and `--debug-hotkey`: every other modifier arrives, fn alone is absent. An alternative hotkey makes parrot usable there (and for anyone whose fn key is otherwise claimed).

## Testing

Built and ran on the affected machine. `--hotkey right-option`: press/release cycles record, transcribe, and type correctly, left option does not trigger it. Default fn path unchanged (verified via synthesized fn flagsChanged events, since the hardware key never emits on this OS build).