### PR TITLE
models: cache weights outside ~/Documents so the LaunchAgent can load them

### DIFF
--- a/Sources/parrot/Transcription/WhisperKitTranscriber.swift
+++ b/Sources/parrot/Transcription/WhisperKitTranscriber.swift
@@ -11,6 +11,23 @@ actor WhisperKitTranscriber: Transcriber {
         self.model = model
     }
 
+    /// Where model weights are cached.
+    ///
+    /// WhisperKit delegates downloads to HubApi, which defaults to
+    /// ~/Documents/huggingface. ~/Documents is TCC-protected on macOS: a process
+    /// launched from a terminal inherits the terminal's access, but one started by
+    /// launchd has none of its own, so model loading fails with a permission
+    /// error. Application Support sits outside TCC, so caching there keeps the
+    /// LaunchAgent working without granting parrot access to Documents — fewer
+    /// privileges, not more.
+    static var modelCacheDirectory: URL {
+        let base = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent("Library/Application Support", isDirectory: true)
+        return base.appendingPathComponent("parrot", isDirectory: true)
+    }
+
     /// Loads the model into memory; downloads first if not already on disk.
     /// Call once at startup so the first hotkey press isn't blocked on model
     /// download/load.
@@ -20,7 +37,17 @@ actor WhisperKitTranscriber: Transcriber {
             throw TranscriberError.missingEngineID
         }
         FileHandle.standardError.write(Data("loading \(model.id)...\n".utf8))
-        let config = WhisperKitConfig(model: whisperKitID, verbose: false, prewarm: true, load: true)
+
+        let cache = Self.modelCacheDirectory
+        try FileManager.default.createDirectory(at: cache, withIntermediateDirectories: true)
+
+        let config = WhisperKitConfig(
+            model: whisperKitID,
+            downloadBase: cache,
+            verbose: false,
+            prewarm: true,
+            load: true
+        )
         pipeline = try await WhisperKit(config)
         FileHandle.standardError.write(Data("✓ \(model.id) ready\n".utf8))
     }


### PR DESCRIPTION
`parrot install --launch-at-login` cannot start on a clean machine. The agent
loads the model, fails, exits 1, and — because the generated plist sets
`KeepAlive.SuccessfulExit=false` — launchd restarts it in a loop.

## Cause

WhisperKit delegates downloads to `HubApi`, whose `downloadBase` defaults to
`~/Documents/huggingface`. `~/Documents` is TCC-protected on macOS:

- Run from a terminal, parrot inherits the **terminal's** Documents access, so
  model loading works. This is why it isn't visible in normal foreground use.
- Run by launchd, parrot has no Documents access of its own, so `warmUp()`
  fails.

The error also misreports what happened:

    warmup failed: modelsUnavailable("Model not found. Please check the model
    or repo name and try again.\nError: invalidMetadataError("Could not remove
    corrupted metadata file: “model.mil.metadata” couldn’t be removed because
    you don’t have permission to access it.")")

Nothing is corrupt. The directory is unreadable, and HubApi surfaces that as a
metadata error while trying to clean up.

## Fix

Pass an explicit `downloadBase` of `~/Library/Application Support/parrot`,
which is outside TCC. I chose this over granting parrot access to Documents or
Full Disk Access because it needs *fewer* privileges, not more — the daemon
already holds Accessibility and Microphone, and adding a third broad grant to
reach a cache directory seemed like the wrong direction.

## Existing users

Weights are kept by moving the cache once, rather than re-downloading:

    mkdir -p ~/Library/Application\ Support/parrot
    mv ~/Documents/huggingface/models ~/Library/Application\ Support/parrot/models

Worth a README note; happy to add one here if you'd like it in the same PR.

## Verified

- Before the change, under launchd: the `invalidMetadataError` above, `runs`
  incrementing on a loop.
- After, under launchd: `✓ whisper-base.en ready`, then `listening on fn hold`,
  `runs = 1`, no restarts. Dictation into a native text field works end to end,
  with the migrated cache and no re-download.
- Foreground use is unaffected: `parrot models download whisper-base.en`
  resolves from the new location.
- `swift build -c release` clean on this commit alone.

Not verified: only tested with `whisper-base.en` on macOS 15 / Apple Silicon,
and only with a migrated cache — I did not test a first-run download into the
new location from scratch.

## Relationship to #9

Complementary, no overlap. #9 hardens *where the daemon writes its logs*; this
fixes the daemon being unable to start at all. Different files, so no conflict
— #9 touches `Install.swift`/`Parrot.swift`, this only touches
`WhisperKitTranscriber.swift`.
