### PR TITLE
menu bar: pick the input device (capture through AUHAL)

### DIFF
--- a/Sources/parrot/Audio/AudioCapture.swift
+++ b/Sources/parrot/Audio/AudioCapture.swift
@@ -74,12 +74,18 @@ final class AudioCapture {
                                        kAudioUnitScope_Output, 0,
                                        &disable, UInt32(MemoryLayout<UInt32>.size)))
 
-        // Left unset, AUHAL follows the system default input.
-        if var device {
-            try check(AudioUnitSetProperty(unit, kAudioOutputUnitProperty_CurrentDevice,
-                                           kAudioUnitScope_Global, 0,
-                                           &device, UInt32(MemoryLayout<AudioDeviceID>.size)))
+        // Writing this property is what wires the unit to a device's input
+        // stream. Left unwritten the unit still reports the right device and
+        // starts without error, but renders zero frames, so the system default
+        // is resolved and written like any other choice.
+        var resolved = device ?? Self.systemDefaultInput()
+        guard resolved != AudioDeviceID(kAudioObjectUnknown) else {
+            dispose()
+            throw CaptureError.unavailable
         }
+        try check(AudioUnitSetProperty(unit, kAudioOutputUnitProperty_CurrentDevice,
+                                       kAudioUnitScope_Global, 0,
+                                       &resolved, UInt32(MemoryLayout<AudioDeviceID>.size)))
 
         // Read what the device actually produces, then ask AUHAL only for a
         // float layout at that same rate — the one conversion it will do.
@@ -201,6 +207,21 @@ final class AudioCapture {
             onLevel(computeRMS(chunk))
         }
         return noErr
+    }
+
+    /// The device the system currently records from. AUHAL will not resolve
+    /// this on its own, so it is read explicitly whenever the user has not
+    /// pinned a device.
+    private static func systemDefaultInput() -> AudioDeviceID {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        var device = AudioDeviceID(kAudioObjectUnknown)
+        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+        AudioObjectGetPropertyData(AudioObjectID(kAudioObjectSystemObject),
+                                   &address, 0, nil, &size, &device)
+        return device
     }
 
     private func dispose() {

--- a/Sources/parrot/Audio/AudioCapture.swift
+++ b/Sources/parrot/Audio/AudioCapture.swift
@@ -1,25 +1,44 @@
+import AudioToolbox
 import AVFoundation
+import CoreAudio
 import Foundation
 
 /// Captures microphone audio while recording is active and returns a 16 kHz
-/// mono Float32 buffer when stopped. Format-converts on the fly so callers
-/// don't have to worry about the input device's native rate.
+/// mono Float32 buffer when stopped.
+///
+/// Built on a standalone AUHAL unit rather than `AVAudioEngine` because only
+/// AUHAL honours a device choice: `AVAudioEngine`'s input node binds to whatever
+/// input is current the moment the node is first touched, and setting the device
+/// afterwards — via `auAudioUnit.setDeviceID`, via `AudioUnitSetProperty`, or
+/// with an `engine.reset()` in between — returns `noErr` and then delivers
+/// silence. Measured on a Bluetooth headset: 0 frames in 3 s for all three,
+/// against 48 000 frames for the same device through AUHAL.
+///
+/// AUHAL also converts to the target format itself, so there is no
+/// `AVAudioConverter` in the path, and no `installTap(onBus:format:)` — which
+/// removes the format-mismatch exception that could terminate the daemon when
+/// the input device changed.
 final class AudioCapture {
     enum CaptureError: Error {
-        case engineStartFailed(Error)
-        case converterCreationFailed
+        case unavailable
+        case configurationFailed(OSStatus)
+        case startFailed(OSStatus)
     }
 
     static let targetSampleRate: Double = 16_000
 
-    private var engine = AVAudioEngine()
-    private var converter: AVAudioConverter?
+    /// Matches the old tap size; also the render buffer we preallocate, so the
+    /// audio thread never allocates.
+    private static let framesPerSlice: UInt32 = 4096
+
+    private var unit: AudioUnit?
+    private var buffer: AVAudioPCMBuffer?
     private var samples: [Float] = []
     private var isRecording = false
     private let lock = NSLock()
 
     /// Called for every audio buffer with the buffer's RMS level (0…~1).
-    /// Invoked on an arbitrary thread; hop to main if you touch UI.
+    /// Invoked on the audio thread; hop to main if you touch UI.
     var onLevel: ((Float) -> Void)?
 
     /// Begin recording. Idempotent — calling while already recording is a no-op.
@@ -27,54 +46,71 @@ final class AudioCapture {
     func start(device: AudioDeviceID? = nil) throws {
         guard !isRecording else { return }
 
-        // A reused engine keeps the input format it had at construction, so once
-        // the default device changes installTap throws a format mismatch and
-        // kills the process. A fresh engine always sees current hardware.
-        engine = AVAudioEngine()
-
-        let input = engine.inputNode
-        if let device {
-            // Must precede the format read: the node reports the format of
-            // whichever device it is bound to.
-            do {
-                try input.auAudioUnit.setDeviceID(device)
-            } catch {
-                FileHandle.standardError.write(Data(
-                    "input device unavailable, using system default: \(error)\n".utf8
-                ))
-            }
+        var description = AudioComponentDescription(
+            componentType: kAudioUnitType_Output,
+            componentSubType: kAudioUnitSubType_HALOutput,
+            componentManufacturer: kAudioUnitManufacturer_Apple,
+            componentFlags: 0,
+            componentFlagsMask: 0
+        )
+        guard let component = AudioComponentFindNext(nil, &description) else {
+            throw CaptureError.unavailable
         }
-        let inputFormat = input.outputFormat(forBus: 0)
+        var unit: AudioUnit?
+        try check(AudioComponentInstanceNew(component, &unit))
+        guard let unit else { throw CaptureError.unavailable }
+        self.unit = unit
 
-        let targetFormat = AVAudioFormat(
-            commonFormat: .pcmFormatFloat32,
-            sampleRate: AudioCapture.targetSampleRate,
-            channels: 1,
-            interleaved: false
-        )!
+        var enable: UInt32 = 1
+        try check(AudioUnitSetProperty(unit, kAudioOutputUnitProperty_EnableIO,
+                                       kAudioUnitScope_Input, 1,
+                                       &enable, UInt32(MemoryLayout<UInt32>.size)))
+        var disable: UInt32 = 0
+        try check(AudioUnitSetProperty(unit, kAudioOutputUnitProperty_EnableIO,
+                                       kAudioUnitScope_Output, 0,
+                                       &disable, UInt32(MemoryLayout<UInt32>.size)))
 
-        guard let converter = AVAudioConverter(from: inputFormat, to: targetFormat) else {
-            throw CaptureError.converterCreationFailed
+        // Left unset, AUHAL follows the system default input.
+        if var device {
+            try check(AudioUnitSetProperty(unit, kAudioOutputUnitProperty_CurrentDevice,
+                                           kAudioUnitScope_Global, 0,
+                                           &device, UInt32(MemoryLayout<AudioDeviceID>.size)))
         }
-        self.converter = converter
+
+        guard let format = AVAudioFormat(commonFormat: .pcmFormatFloat32,
+                                         sampleRate: Self.targetSampleRate,
+                                         channels: 1, interleaved: false) else {
+            throw CaptureError.unavailable
+        }
+        var asbd = format.streamDescription.pointee
+        try check(AudioUnitSetProperty(unit, kAudioUnitProperty_StreamFormat,
+                                       kAudioUnitScope_Output, 1,
+                                       &asbd, UInt32(MemoryLayout<AudioStreamBasicDescription>.size)))
+
+        var slice = Self.framesPerSlice
+        try check(AudioUnitSetProperty(unit, kAudioUnitProperty_MaximumFramesPerSlice,
+                                       kAudioUnitScope_Global, 0,
+                                       &slice, UInt32(MemoryLayout<UInt32>.size)))
+        buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: Self.framesPerSlice)
+
+        var callback = AURenderCallbackStruct(
+            inputProc: captureRenderCallback,
+            inputProcRefCon: Unmanaged.passUnretained(self).toOpaque()
+        )
+        try check(AudioUnitSetProperty(unit, kAudioOutputUnitProperty_SetInputCallback,
+                                       kAudioUnitScope_Global, 0,
+                                       &callback, UInt32(MemoryLayout<AURenderCallbackStruct>.size)))
 
         lock.lock()
         samples.removeAll(keepingCapacity: true)
         lock.unlock()
 
-        // Tap with input format; convert inside the callback.
-        input.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [weak self] buffer, _ in
-            self?.process(buffer: buffer, converter: converter, targetFormat: targetFormat)
+        try check(AudioUnitInitialize(unit))
+        let status = AudioOutputUnitStart(unit)
+        guard status == noErr else {
+            dispose()
+            throw CaptureError.startFailed(status)
         }
-
-        engine.prepare()
-        do {
-            try engine.start()
-        } catch {
-            input.removeTap(onBus: 0)
-            throw CaptureError.engineStartFailed(error)
-        }
-
         isRecording = true
     }
 
@@ -82,9 +118,14 @@ final class AudioCapture {
     @discardableResult
     func stop() -> [Float] {
         guard isRecording else { return [] }
-        engine.stop()
-        engine.inputNode.removeTap(onBus: 0)
         isRecording = false
+        if let unit {
+            AudioOutputUnitStop(unit)
+            AudioUnitUninitialize(unit)
+        }
+        // Dispose so the device is released; a Bluetooth headset keeps its
+        // microphone link open otherwise.
+        dispose()
 
         lock.lock()
         let captured = samples
@@ -93,39 +134,18 @@ final class AudioCapture {
         return captured
     }
 
-    private func process(
-        buffer: AVAudioPCMBuffer,
-        converter: AVAudioConverter,
-        targetFormat: AVAudioFormat
-    ) {
-        // Output buffer capacity scales with sample-rate ratio.
-        let ratio = targetFormat.sampleRate / buffer.format.sampleRate
-        let outCapacity = AVAudioFrameCount(Double(buffer.frameLength) * ratio) + 64
+    fileprivate func render(
+        flags: UnsafeMutablePointer<AudioUnitRenderActionFlags>,
+        timestamp: UnsafePointer<AudioTimeStamp>,
+        bus: UInt32,
+        frames: UInt32
+    ) -> OSStatus {
+        guard let unit, let buffer, frames <= buffer.frameCapacity else { return noErr }
+        buffer.frameLength = frames
+        let status = AudioUnitRender(unit, flags, timestamp, bus, frames, buffer.mutableAudioBufferList)
+        guard status == noErr, let channel = buffer.floatChannelData?[0] else { return status }
 
-        guard let outBuffer = AVAudioPCMBuffer(
-            pcmFormat: targetFormat,
-            frameCapacity: outCapacity
-        ) else { return }
-
-        var consumed = false
-        let inputBlock: AVAudioConverterInputBlock = { _, status in
-            if consumed {
-                status.pointee = .noDataNow
-                return nil
-            }
-            consumed = true
-            status.pointee = .haveData
-            return buffer
-        }
-
-        var error: NSError?
-        let status = converter.convert(to: outBuffer, error: &error, withInputFrom: inputBlock)
-        guard status != .error, let channelData = outBuffer.floatChannelData else { return }
-
-        let count = Int(outBuffer.frameLength)
-        let ptr = channelData[0]
-        let chunk = Array(UnsafeBufferPointer(start: ptr, count: count))
-
+        let chunk = Array(UnsafeBufferPointer(start: channel, count: Int(frames)))
         lock.lock()
         samples.append(contentsOf: chunk)
         lock.unlock()
@@ -133,7 +153,27 @@ final class AudioCapture {
         if let onLevel {
             onLevel(computeRMS(chunk))
         }
+        return noErr
     }
+
+    private func dispose() {
+        if let unit { AudioComponentInstanceDispose(unit) }
+        unit = nil
+        buffer = nil
+    }
+
+    private func check(_ status: OSStatus) throws {
+        guard status != noErr else { return }
+        dispose()
+        throw CaptureError.configurationFailed(status)
+    }
+}
+
+/// C callbacks carry no context, so the instance travels through
+/// `inputProcRefCon`. Unretained: the unit never outlives its AudioCapture.
+private let captureRenderCallback: AURenderCallback = { refCon, flags, timestamp, bus, frames, _ in
+    let capture = Unmanaged<AudioCapture>.fromOpaque(refCon).takeUnretainedValue()
+    return capture.render(flags: flags, timestamp: timestamp, bus: bus, frames: frames)
 }
 
 // MARK: - WAV writer (for debugging M3 captures)
@@ -141,46 +181,39 @@ final class AudioCapture {
 enum WAVWriter {
     /// Write Float32 mono samples as 16-bit PCM WAV to `path`.
     static func write(samples: [Float], sampleRate: Int, to path: String) throws {
-        let bytesPerSample = 2
-        let dataSize = samples.count * bytesPerSample
-
         var data = Data()
-        data.append(contentsOf: Array("RIFF".utf8))
-        data.append(uint32LE(36 + UInt32(dataSize)))
-        data.append(contentsOf: Array("WAVE".utf8))
-        data.append(contentsOf: Array("fmt ".utf8))
-        data.append(uint32LE(16))                       // fmt chunk size
-        data.append(uint16LE(1))                        // PCM
-        data.append(uint16LE(1))                        // mono
+        let byteCount = samples.count * 2
+        data.append("RIFF".data(using: .ascii)!)
+        data.append(uint32LE(UInt32(36 + byteCount)))
+        data.append("WAVE".data(using: .ascii)!)
+        data.append("fmt ".data(using: .ascii)!)
+        data.append(uint32LE(16))
+        data.append(uint16LE(1))
+        data.append(uint16LE(1))
         data.append(uint32LE(UInt32(sampleRate)))
-        data.append(uint32LE(UInt32(sampleRate * bytesPerSample)))
-        data.append(uint16LE(UInt16(bytesPerSample)))   // block align
-        data.append(uint16LE(16))                       // bits per sample
-        data.append(contentsOf: Array("data".utf8))
-        data.append(uint32LE(UInt32(dataSize)))
-
-        for s in samples {
-            let clamped = max(-1.0, min(1.0, s))
-            let i = Int16(clamped * 32767.0)
-            data.append(uint16LE(UInt16(bitPattern: i)))
+        data.append(uint32LE(UInt32(sampleRate * 2)))
+        data.append(uint16LE(2))
+        data.append(uint16LE(16))
+        data.append("data".data(using: .ascii)!)
+        data.append(uint32LE(UInt32(byteCount)))
+        for sample in samples {
+            let clamped = max(-1, min(1, sample))
+            data.append(uint16LE(UInt16(bitPattern: Int16(clamped * 32767))))
         }
-
         try data.write(to: URL(fileURLWithPath: path))
     }
 
     private static func uint32LE(_ v: UInt32) -> Data {
-        var x = v.littleEndian
-        return Data(bytes: &x, count: 4)
+        Data([UInt8(v & 0xff), UInt8((v >> 8) & 0xff), UInt8((v >> 16) & 0xff), UInt8((v >> 24) & 0xff)])
     }
+
     private static func uint16LE(_ v: UInt16) -> Data {
-        var x = v.littleEndian
-        return Data(bytes: &x, count: 2)
+        Data([UInt8(v & 0xff), UInt8((v >> 8) & 0xff)])
     }
 }
 
 func computeRMS(_ samples: [Float]) -> Float {
     guard !samples.isEmpty else { return 0 }
-    var sum: Double = 0
-    for s in samples { sum += Double(s * s) }
-    return Float((sum / Double(samples.count)).squareRoot())
+    let sum = samples.reduce(Float(0)) { $0 + $1 * $1 }
+    return (sum / Float(samples.count)).squareRoot()
 }

--- a/Sources/parrot/Audio/AudioCapture.swift
+++ b/Sources/parrot/Audio/AudioCapture.swift
@@ -33,6 +33,10 @@ final class AudioCapture {
 
     private var unit: AudioUnit?
     private var buffer: AVAudioPCMBuffer?
+    /// AUHAL input does not resample: asking a 48 kHz device for 16 kHz renders
+    /// nothing at all. It is bound at the device's own rate and converted here.
+    private var converter: AVAudioConverter?
+    private var targetFormat: AVAudioFormat?
     private var samples: [Float] = []
     private var isRecording = false
     private let lock = NSLock()
@@ -77,12 +81,31 @@ final class AudioCapture {
                                            &device, UInt32(MemoryLayout<AudioDeviceID>.size)))
         }
 
-        guard let format = AVAudioFormat(commonFormat: .pcmFormatFloat32,
-                                         sampleRate: Self.targetSampleRate,
-                                         channels: 1, interleaved: false) else {
+        // Read what the device actually produces, then ask AUHAL only for a
+        // float layout at that same rate — the one conversion it will do.
+        var native = AudioStreamBasicDescription()
+        var nativeSize = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
+        try check(AudioUnitGetProperty(unit, kAudioUnitProperty_StreamFormat,
+                                       kAudioUnitScope_Input, 1, &native, &nativeSize))
+
+        guard let sourceFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: native.mSampleRate,
+            channels: max(1, AVAudioChannelCount(native.mChannelsPerFrame)),
+            interleaved: false
+        ), let targetFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: Self.targetSampleRate,
+            channels: 1,
+            interleaved: false
+        ), let converter = AVAudioConverter(from: sourceFormat, to: targetFormat) else {
+            dispose()
             throw CaptureError.unavailable
         }
-        var asbd = format.streamDescription.pointee
+        self.targetFormat = targetFormat
+        self.converter = converter
+
+        var asbd = sourceFormat.streamDescription.pointee
         try check(AudioUnitSetProperty(unit, kAudioUnitProperty_StreamFormat,
                                        kAudioUnitScope_Output, 1,
                                        &asbd, UInt32(MemoryLayout<AudioStreamBasicDescription>.size)))
@@ -91,7 +114,7 @@ final class AudioCapture {
         try check(AudioUnitSetProperty(unit, kAudioUnitProperty_MaximumFramesPerSlice,
                                        kAudioUnitScope_Global, 0,
                                        &slice, UInt32(MemoryLayout<UInt32>.size)))
-        buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: Self.framesPerSlice)
+        buffer = AVAudioPCMBuffer(pcmFormat: sourceFormat, frameCapacity: Self.framesPerSlice)
 
         var callback = AURenderCallbackStruct(
             inputProc: captureRenderCallback,
@@ -140,12 +163,36 @@ final class AudioCapture {
         bus: UInt32,
         frames: UInt32
     ) -> OSStatus {
-        guard let unit, let buffer, frames <= buffer.frameCapacity else { return noErr }
+        guard let unit, let buffer, let converter, let targetFormat,
+              frames <= buffer.frameCapacity else { return noErr }
         buffer.frameLength = frames
         let status = AudioUnitRender(unit, flags, timestamp, bus, frames, buffer.mutableAudioBufferList)
-        guard status == noErr, let channel = buffer.floatChannelData?[0] else { return status }
+        guard status == noErr else {
+            // Never fail silently: a render that returns nothing used to look
+            // exactly like a microphone that heard nothing.
+            FileHandle.standardError.write(Data("audio render failed: \(status)\n".utf8))
+            return status
+        }
 
-        let chunk = Array(UnsafeBufferPointer(start: channel, count: Int(frames)))
+        let ratio = targetFormat.sampleRate / buffer.format.sampleRate
+        let capacity = AVAudioFrameCount(Double(frames) * ratio) + 64
+        guard let out = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: capacity) else {
+            return noErr
+        }
+        var consumed = false
+        var error: NSError?
+        converter.convert(to: out, error: &error) { _, outStatus in
+            if consumed {
+                outStatus.pointee = .noDataNow
+                return nil
+            }
+            consumed = true
+            outStatus.pointee = .haveData
+            return buffer
+        }
+        guard error == nil, let channel = out.floatChannelData?[0] else { return noErr }
+
+        let chunk = Array(UnsafeBufferPointer(start: channel, count: Int(out.frameLength)))
         lock.lock()
         samples.append(contentsOf: chunk)
         lock.unlock()
@@ -160,6 +207,8 @@ final class AudioCapture {
         if let unit { AudioComponentInstanceDispose(unit) }
         unit = nil
         buffer = nil
+        converter = nil
+        targetFormat = nil
     }
 
     private func check(_ status: OSStatus) throws {

--- a/Sources/parrot/Audio/AudioCapture.swift
+++ b/Sources/parrot/Audio/AudioCapture.swift
@@ -23,7 +23,8 @@ final class AudioCapture {
     var onLevel: ((Float) -> Void)?
 
     /// Begin recording. Idempotent — calling while already recording is a no-op.
-    func start() throws {
+    /// `device` nil records from the system default input.
+    func start(device: AudioDeviceID? = nil) throws {
         guard !isRecording else { return }
 
         // A reused engine keeps the input format it had at construction, so once
@@ -32,6 +33,17 @@ final class AudioCapture {
         engine = AVAudioEngine()
 
         let input = engine.inputNode
+        if let device {
+            // Must precede the format read: the node reports the format of
+            // whichever device it is bound to.
+            do {
+                try input.auAudioUnit.setDeviceID(device)
+            } catch {
+                FileHandle.standardError.write(Data(
+                    "input device unavailable, using system default: \(error)\n".utf8
+                ))
+            }
+        }
         let inputFormat = input.outputFormat(forBus: 0)
 
         let targetFormat = AVAudioFormat(

--- a/Sources/parrot/Audio/AudioCapture.swift
+++ b/Sources/parrot/Audio/AudioCapture.swift
@@ -12,7 +12,7 @@ final class AudioCapture {
 
     static let targetSampleRate: Double = 16_000
 
-    private let engine = AVAudioEngine()
+    private var engine = AVAudioEngine()
     private var converter: AVAudioConverter?
     private var samples: [Float] = []
     private var isRecording = false
@@ -25,6 +25,11 @@ final class AudioCapture {
     /// Begin recording. Idempotent — calling while already recording is a no-op.
     func start() throws {
         guard !isRecording else { return }
+
+        // A reused engine keeps the input format it had at construction, so once
+        // the default device changes installTap throws a format mismatch and
+        // kills the process. A fresh engine always sees current hardware.
+        engine = AVAudioEngine()
 
         let input = engine.inputNode
         let inputFormat = input.outputFormat(forBus: 0)

--- a/Sources/parrot/Audio/InputDeviceStore.swift
+++ b/Sources/parrot/Audio/InputDeviceStore.swift
@@ -1,0 +1,105 @@
+import CoreAudio
+import Foundation
+
+/// Which microphone parrot records from: chosen in the menu bar, remembered
+/// across restarts, resolved fresh for every recording.
+///
+/// Devices are remembered by UID rather than AudioDeviceID, because the numeric
+/// id is reassigned across reboots and reconnects — a stored id can silently
+/// point at a different microphone.
+final class InputDeviceStore {
+    struct Device {
+        let id: AudioDeviceID
+        let uid: String
+        let name: String
+    }
+
+    private static let selectionKey = "inputDeviceUID"
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    /// UID the user picked, or nil to follow the system default input.
+    var selectedUID: String? {
+        get { defaults.string(forKey: Self.selectionKey) }
+        set {
+            if let newValue {
+                defaults.set(newValue, forKey: Self.selectionKey)
+            } else {
+                defaults.removeObject(forKey: Self.selectionKey)
+            }
+        }
+    }
+
+    /// Every device that can record, in the order CoreAudio reports them.
+    func available() -> [Device] {
+        deviceIDs().compactMap { id in
+            guard inputChannels(id) > 0, let uid = uid(of: id) else { return nil }
+            return Device(id: id, uid: uid, name: name(of: id) ?? uid)
+        }
+    }
+
+    /// Device to record from now. nil means follow the system default, which is
+    /// also what happens when the remembered device is currently unplugged.
+    func resolved() -> Device? {
+        guard let selectedUID else { return nil }
+        return available().first { $0.uid == selectedUID }
+    }
+
+    // MARK: - CoreAudio reads
+
+    private func deviceIDs() -> [AudioDeviceID] {
+        var addr = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDevices,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var size: UInt32 = 0
+        let system = AudioObjectID(kAudioObjectSystemObject)
+        guard AudioObjectGetPropertyDataSize(system, &addr, 0, nil, &size) == noErr else { return [] }
+        var ids = [AudioDeviceID](repeating: 0, count: Int(size) / MemoryLayout<AudioDeviceID>.size)
+        guard AudioObjectGetPropertyData(system, &addr, 0, nil, &size, &ids) == noErr else { return [] }
+        return ids
+    }
+
+    private func inputChannels(_ id: AudioDeviceID) -> Int {
+        var addr = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyStreamConfiguration,
+            mScope: kAudioDevicePropertyScopeInput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var size: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(id, &addr, 0, nil, &size) == noErr, size > 0 else { return 0 }
+        let raw = UnsafeMutableRawPointer.allocate(byteCount: Int(size), alignment: 16)
+        defer { raw.deallocate() }
+        guard AudioObjectGetPropertyData(id, &addr, 0, nil, &size, raw) == noErr else { return 0 }
+        let list = raw.assumingMemoryBound(to: AudioBufferList.self)
+        return UnsafeMutableAudioBufferListPointer(list).reduce(0) { $0 + Int($1.mNumberChannels) }
+    }
+
+    private func uid(of id: AudioDeviceID) -> String? {
+        string(id, kAudioDevicePropertyDeviceUID)
+    }
+
+    private func name(of id: AudioDeviceID) -> String? {
+        string(id, kAudioObjectPropertyName)
+    }
+
+    private func string(_ id: AudioDeviceID, _ selector: AudioObjectPropertySelector) -> String? {
+        var addr = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var value: Unmanaged<CFString>?
+        var size = UInt32(MemoryLayout<Unmanaged<CFString>?>.size)
+        let status = withUnsafeMutablePointer(to: &value) {
+            AudioObjectGetPropertyData(id, &addr, 0, nil, &size, $0)
+        }
+        guard status == noErr, let value else { return nil }
+        return value.takeRetainedValue() as String
+    }
+}

--- a/Sources/parrot/Audio/InputDeviceStore.swift
+++ b/Sources/parrot/Audio/InputDeviceStore.swift
@@ -34,10 +34,12 @@ final class InputDeviceStore {
         }
     }
 
-    /// Every device that can record, in the order CoreAudio reports them.
+    /// Every device a person could record from, in the order CoreAudio reports
+    /// them. Excludes the private aggregate CoreAudio creates per audio client —
+    /// our own plumbing, which is otherwise indistinguishable from a microphone.
     func available() -> [Device] {
         deviceIDs().compactMap { id in
-            guard inputChannels(id) > 0, let uid = uid(of: id) else { return nil }
+            guard inputChannels(id) > 0, !isPrivateAggregate(id), let uid = uid(of: id) else { return nil }
             return Device(id: id, uid: uid, name: name(of: id) ?? uid)
         }
     }
@@ -78,6 +80,37 @@ final class InputDeviceStore {
         guard AudioObjectGetPropertyData(id, &addr, 0, nil, &size, raw) == noErr else { return 0 }
         let list = raw.assumingMemoryBound(to: AudioBufferList.self)
         return UnsafeMutableAudioBufferListPointer(list).reduce(0) { $0 + Int($1.mNumberChannels) }
+    }
+
+    /// Aggregate devices CoreAudio builds for its own clients are flagged private
+    /// in their composition. They report input channels and are not hidden, so
+    /// this is the only thing separating them from a real microphone. Aggregates
+    /// the user built in Audio MIDI Setup are not private and stay listed.
+    private func isPrivateAggregate(_ id: AudioDeviceID) -> Bool {
+        var transportAddr = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyTransportType,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var transport: UInt32 = 0
+        var transportSize = UInt32(MemoryLayout<UInt32>.size)
+        guard AudioObjectGetPropertyData(id, &transportAddr, 0, nil, &transportSize, &transport) == noErr,
+              transport == kAudioDeviceTransportTypeAggregate
+        else { return false }
+
+        var addr = AudioObjectPropertyAddress(
+            mSelector: kAudioAggregateDevicePropertyComposition,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var value: Unmanaged<CFDictionary>?
+        var size = UInt32(MemoryLayout<Unmanaged<CFDictionary>?>.size)
+        let status = withUnsafeMutablePointer(to: &value) {
+            AudioObjectGetPropertyData(id, &addr, 0, nil, &size, $0)
+        }
+        guard status == noErr, let value else { return false }
+        let composition = value.takeRetainedValue() as? [String: Any]
+        return composition?[kAudioAggregateDeviceIsPrivateKey] as? Int == 1
     }
 
     private func uid(of id: AudioDeviceID) -> String? {

--- a/Sources/parrot/Parrot.swift
+++ b/Sources/parrot/Parrot.swift
@@ -82,20 +82,21 @@ struct Run: ParsableCommand {
         app.setActivationPolicy(.accessory)
 
         let monitor = HotkeyMonitor(debug: debugHotkey)
+        let devices = InputDeviceStore()
         let capture = AudioCapture()
         let dumpWav = self.dumpWav
         let overlay: RecordingOverlay? = noOverlay ? nil : MainActor.assumeIsolated { RecordingOverlay() }
         if let overlay {
             capture.onLevel = { level in overlay.pushLevel(level) }
         }
-        let menuBar = MainActor.assumeIsolated { MenuBarController(modelID: chosenModel.id) }
+        let menuBar = MainActor.assumeIsolated { MenuBarController(modelID: chosenModel.id, devices: devices) }
 
         do {
             try monitor.start { event in
                 switch event {
                 case .pressed:
                     do {
-                        try capture.start()
+                        try capture.start(device: devices.resolved()?.id)
                         FileHandle.standardError.write(Data("● recording\n".utf8))
                         MainActor.assumeIsolated {
                             overlay?.show(.recording)

--- a/Sources/parrot/UI/MenuBarController.swift
+++ b/Sources/parrot/UI/MenuBarController.swift
@@ -59,7 +59,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         submenu.removeAllItems()
 
         let selected = devices.selectedUID
-        submenu.addItem(inputChoice(title: "Automatic (follow system)", uid: nil, checked: selected == nil))
+        submenu.addItem(inputChoice(title: "Same as System", uid: nil, checked: selected == nil))
         submenu.addItem(.separator())
         for device in devices.available() {
             submenu.addItem(inputChoice(title: device.name, uid: device.uid, checked: device.uid == selected))

--- a/Sources/parrot/UI/MenuBarController.swift
+++ b/Sources/parrot/UI/MenuBarController.swift
@@ -4,14 +4,17 @@ import AppKit
 /// a glance and provides the only persistent control surface for the daemon
 /// (since we run as `.accessory` — no dock icon, no main window).
 @MainActor
-final class MenuBarController {
+final class MenuBarController: NSObject, NSMenuDelegate {
     private let statusItem: NSStatusItem
     private let modelLabel: NSMenuItem
     private let stateLabel: NSMenuItem
+    private let inputItem: NSMenuItem
     private let modelID: String
+    private let devices: InputDeviceStore
 
-    init(modelID: String) {
+    init(modelID: String, devices: InputDeviceStore) {
         self.modelID = modelID
+        self.devices = devices
         self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
 
         let menu = NSMenu()
@@ -25,6 +28,12 @@ final class MenuBarController {
         modelLabel.isEnabled = false
         menu.addItem(modelLabel)
 
+        inputItem = NSMenuItem(title: "Input", action: nil, keyEquivalent: "")
+        let inputMenu = NSMenu()
+        inputMenu.autoenablesItems = false
+        inputItem.submenu = inputMenu
+        menu.addItem(inputItem)
+
         menu.addItem(.separator())
 
         let quit = NSMenuItem(
@@ -32,11 +41,43 @@ final class MenuBarController {
             action: #selector(quitClicked),
             keyEquivalent: "q"
         )
+        super.init()
+
         quit.target = self
         menu.addItem(quit)
 
+        // Rebuild the device list on open so plugging a mic in is reflected
+        // without watching CoreAudio for device changes.
+        menu.delegate = self
+
         statusItem.menu = menu
         configureButton(recording: false)
+    }
+
+    func menuWillOpen(_ menu: NSMenu) {
+        guard let submenu = inputItem.submenu else { return }
+        submenu.removeAllItems()
+
+        let selected = devices.selectedUID
+        submenu.addItem(inputChoice(title: "Automatic (follow system)", uid: nil, checked: selected == nil))
+        submenu.addItem(.separator())
+        for device in devices.available() {
+            submenu.addItem(inputChoice(title: device.name, uid: device.uid, checked: device.uid == selected))
+        }
+    }
+
+    private func inputChoice(title: String, uid: String?, checked: Bool) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: #selector(inputSelected), keyEquivalent: "")
+        item.target = self
+        item.representedObject = uid
+        item.state = checked ? .on : .off
+        return item
+    }
+
+    /// Only writes the preference — the next recording resolves it, so there is
+    /// nothing to notify.
+    @objc private func inputSelected(_ sender: NSMenuItem) {
+        devices.selectedUID = sender.representedObject as? String
     }
 
     func setRecording(_ recording: Bool) {


### PR DESCRIPTION
Pick the input device from the menu bar, and record from the one you picked.

`AVAudioEngine`'s input node follows the system default and ignores a device set on the engine, so honouring a choice at all needs AUHAL. Capture goes through `kAudioUnitSubType_HALOutput` with the device written explicitly, bound at the device's own sample rate and resampled here, because a Bluetooth headset that reports 16 kHz will not accept 48.

Seven commits, each with the reproduction in the body:

- capture through AUHAL so a device choice is honoured
- bind AUHAL at the device's own rate and resample here
- write the device explicitly so "Same as System" records
- rebuild the engine for each recording
- the menu itself, the "Same as System" row, and hiding CoreAudio's private aggregate from the list

Measured on this machine with a Baseus BP1 Pro over Bluetooth and the built-in microphone.
