### PR TITLE
detect the spoken language instead of assuming English

### DIFF
--- a/Sources/parrot/Transcription/WhisperKitTranscriber.swift
+++ b/Sources/parrot/Transcription/WhisperKitTranscriber.swift
@@ -29,7 +29,10 @@ actor WhisperKitTranscriber: Transcriber {
         if pipeline == nil { try await warmUp() }
         guard let pipeline else { throw TranscriberError.notLoaded }
 
-        let results = try await pipeline.transcribe(audioArray: audio)
+        // Without this WhisperKit falls back to Constants.defaultLanguageCode ("en")
+        // and tells a multilingual model the audio is English, whatever was said.
+        let options = DecodingOptions(detectLanguage: true)
+        let results = try await pipeline.transcribe(audioArray: audio, decodeOptions: options)
         let raw = results.map(\.text).joined(separator: " ")
         return Self.sanitize(raw)
     }


### PR DESCRIPTION
## Problem

`transcribe(audioArray:)` is called with no `DecodingOptions`, and the defaults
pin English on a multilingual model. The chain:

```swift
// Configurations.swift
self.detectLanguage = detectLanguage ?? !usePrefillPrompt   // usePrefillPrompt defaults true -> false

// TranscribeTask.swift
if textDecoder.isModelMultilingual, options.language == nil, options.detectLanguage { ... }

// TextDecoder.swift
let languageTokenString = "<|\(options.language ?? Constants.defaultLanguageCode)|>"

// Models.swift
public static let defaultLanguageCode: String = "en"
```

`language` is nil and `detectLanguage` resolves to false, so detection never
runs and the decoder is prefilled with `<|en|>` regardless of what was spoken.
Every non-English user of parrot is currently telling `whisper-large-v3-turbo`
that their speech is English.

## Fix

Pass `DecodingOptions(detectLanguage: true)`. No configuration, no language
flag, nothing to maintain — the model reports the language it actually heard.

## Honest measurement

Tested on a 5.7 s Portuguese sample containing English technical terms
("Preciso revisar os pull requests antes do merge e depois fazer o deploy do
back-end"), decoding the same audio under three settings:

| setting | reported language | text |
|---|---|---|
| current default | `en` | identical |
| `detectLanguage: true` | `pt` | identical |
| `language: "pt"` | `pt` | identical |

The output text was **byte-identical** in all three. large-v3-turbo is robust
enough to transcribe Portuguese correctly even when told the audio is English,
so this is a correctness fix, not an accuracy improvement — I am not claiming
better transcriptions, only that the model is no longer given a false premise
and that `result.language` becomes meaningful for anything downstream.

Cost is one extra decoder pass per utterance; on this hardware it was not
measurable against the 0.8–1.9 s transcription time.

## Alternative considered

Exposing `--language` as a CLI flag. Rejected: it needs the user to know and
maintain the setting, and it breaks the moment they dictate in another language,
which detection handles per utterance for free.

No PR CI exists in this repo (`release.yml` runs only on `v*` tags), so this was
built locally with `swift build -c release` — clean, no warnings.
