### PR TITLE
Re-enable the event tap when the system disables it; verify installer checksum

### DIFF
--- a/Sources/parrot/Input/HotkeyMonitor.swift
+++ b/Sources/parrot/Input/HotkeyMonitor.swift
@@ -35,10 +35,17 @@ final class HotkeyMonitor {
             throw HotkeyError.tapCreateFailed
         }
 
-        let mask: CGEventMask =
-            (1 << CGEventType.flagsChanged.rawValue)
-            | (1 << CGEventType.keyDown.rawValue)
-            | (1 << CGEventType.keyUp.rawValue)
+        // Only flagsChanged is ever acted on in `handle`. keyDown/keyUp are
+        // subscribed *only* under --debug-hotkey: listening to every keystroke
+        // system-wide costs main-thread work, raises the odds macOS disables
+        // the tap for timeout, and needlessly exposes typed content (including
+        // password fields) to an Accessibility-privileged process.
+        var mask: CGEventMask = (1 << CGEventType.flagsChanged.rawValue)
+        if debug {
+            mask |=
+                (1 << CGEventType.keyDown.rawValue)
+                | (1 << CGEventType.keyUp.rawValue)
+        }
         let userInfo = Unmanaged.passUnretained(self).toOpaque()
 
         // .cgSessionEventTap is the right level for an accessibility-granted
@@ -76,6 +83,17 @@ final class HotkeyMonitor {
         onEvent = nil
     }
 
+    /// Called from the tap callback when macOS disables our tap. Without this
+    /// the process keeps running, the menu bar icon stays put, and the hotkey
+    /// silently does nothing until the user restarts parrot.
+    fileprivate func reEnable() {
+        guard let tap else { return }
+        CGEvent.tapEnable(tap: tap, enable: true)
+        FileHandle.standardError.write(Data(
+            "event tap was disabled by the system — re-enabled\n".utf8
+        ))
+    }
+
     fileprivate func handle(type: CGEventType, event: CGEvent) {
         if debug {
             let flags = event.flags
@@ -104,8 +122,8 @@ private func hotkeyCallback(
     let monitor = Unmanaged<HotkeyMonitor>.fromOpaque(userInfo).takeUnretainedValue()
 
     if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-        // System disabled our tap; we'll need to re-enable. For now just no-op
-        // and let the user restart parrot.
+        // The tap must be re-enabled from the run loop that owns it.
+        DispatchQueue.main.async { monitor.reEnable() }
         return Unmanaged.passUnretained(event)
     }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -62,6 +62,16 @@ trap 'rm -rf "$TMP"' EXIT
 dim "→ downloading ${ASSET}..."
 curl -fsSL "$URL" -o "$TMP/${ASSET}"
 
+# The release workflow publishes ${ASSET}.sha256 alongside the archive.
+# Verify it: this script installs an unsigned binary and strips its
+# quarantine flag, so the checksum is the only integrity check there is.
+dim "→ verifying checksum..."
+curl -fsSL "${URL}.sha256" -o "$TMP/${ASSET}.sha256"
+( cd "$TMP" && shasum -a 256 -c "${ASSET}.sha256" >/dev/null ) || {
+    red "checksum mismatch for ${ASSET} — refusing to install"
+    exit 1
+}
+
 dim "→ extracting..."
 tar -xzf "$TMP/${ASSET}" -C "$TMP"
 


### PR DESCRIPTION
Two independent fixes found while reading the source before installing parrot on a Mac mini. Happy to split them into separate PRs if you'd prefer.

Built and running locally with both applied (`swift build -c release`, Swift 6.3, macOS 26.5, M-series).

### 1. The event tap is never re-enabled

macOS disables an event tap on `.tapDisabledByTimeout` or `.tapDisabledByUserInput`. The callback treats both as no-ops:

```swift
// System disabled our tap; we'll need to re-enable. For now just no-op
// and let the user restart parrot.
```

The comment is honest about it, but the failure is silent and hard to attribute: parrot keeps running, the menu bar icon stays put, the menu still reads *"idle · hold fn to dictate"* — and `fn` does nothing. For something designed to sit in the menu bar for days, the first symptom is usually "dictation stopped working at some point and I don't know when".

This calls `CGEvent.tapEnable(tap:enable:true)` from the main run loop (the one that owns the tap) and writes a line to stderr so the event is at least visible.

### 2. The tap subscribes to every keystroke and uses none of them

The mask registers `flagsChanged | keyDown | keyUp`, but `handle()` discards everything else on its first line:

```swift
guard type == .flagsChanged else { return }
```

So every keystroke system-wide causes an `event.copy()` and a main-queue dispatch that does nothing. Three costs: needless main-thread work, a higher chance of triggering exactly the timeout above, and typed content — including password fields — passing through a process that holds Accessibility permission. It's `.listenOnly` and entirely local, so nothing leaves the machine; it's just avoidable surface area for a background daemon.

`keyDown`/`keyUp` are still subscribed under `--debug-hotkey`, where they're genuinely used.

### 3. `install.sh` publishes a SHA256 it never checks

`release.yml` builds and uploads `parrot-macos-arm64.tar.gz.sha256`. `install.sh` never fetches it. The script runs as `curl | sh`, downloads an unsigned binary, strips its quarantine attribute and moves it into `/usr/local/bin` — with the checksum sitting unused two lines away. Four lines to close.

---

Separately, and not something for this PR: it might be worth a README note that under `parrot install --launch-at-login` the daemon needs its *own* Accessibility and Microphone grants, distinct from the ones granted to the terminal — and that because the binary is unsigned, TCC keys those grants to the binary hash, so every update invalidates them. It presents as "I updated and it stopped working, but `doctor` says everything is fine", since `doctor` run from a terminal is checking the terminal's grants, not the daemon's.
