### PR TITLE
models list: stop truncating ids

### DIFF
--- a/Sources/parrot/Parrot.swift
+++ b/Sources/parrot/Parrot.swift
@@ -196,9 +196,13 @@ struct Models: ParsableCommand {
 
     struct List: ParsableCommand {
         func run() throws {
+            // Column width follows the longest id: `padding(toLength:)` truncates
+            // when the string is longer, and a truncated id cannot be copied into
+            // `parrot models download`.
+            let width = ModelRegistry.shared.map(\.id.count).max() ?? 26
             for m in ModelRegistry.shared {
                 let star = m.recommended ? "★" : " "
-                let id = m.id.padding(toLength: 26, withPad: " ", startingAt: 0)
+                let id = m.id.padding(toLength: width, withPad: " ", startingAt: 0)
                 let langs = "[\(m.languages.joined(separator: ","))]"
                     .padding(toLength: 9, withPad: " ", startingAt: 0)
                 let size = String(format: "%5d MB", m.sizeMB)


### PR DESCRIPTION
## Problem

`models list` pads the id column with `padding(toLength: 26, …)`, and Swift's
`padding(toLength:)` **truncates** when the string is longer than the target. Any
id past 26 characters is printed cut off, and a cut id cannot be pasted into
`parrot models download`.

Reproducible with any longer id. Adding a 33-character one to the registry:

```
  whisper-large-v3-turbo-com   632 MB  [multi]    Whisper Large v3 Turbo (compressed)
```

The command's whole purpose is to give the user a value to copy, so silently
corrupting it defeats the feature.

## Fix

Size the column to the longest id in the registry instead of a fixed 26. Output
with the same registry:

```
★ whisper-base.en                     145 MB  [en]       Whisper Base (English)
  whisper-large-v3-turbo             1620 MB  [multi]    Whisper Large v3 Turbo
  whisper-large-v3-turbo-compressed   632 MB  [multi]    Whisper Large v3 Turbo (compressed)
  whisper-small.en                    488 MB  [en]       Whisper Small (English)
```

Current ids all fit in 26 characters, so nothing changes for them today — this
only stops the next longer id from being mangled.

Built locally with `swift build -c release` (no PR CI in this repo); clean, no
warnings.
