### PR TITLE
exit 0 when the model id is unknown

### DIFF
--- a/Sources/parrot/Parrot.swift
+++ b/Sources/parrot/Parrot.swift
@@ -50,7 +50,9 @@ struct Run: ParsableCommand {
             guard let m = ModelRegistry.find(id) else {
                 FileHandle.standardError.write(Data("unknown model: \(id)\n".utf8))
                 FileHandle.standardError.write(Data("run `parrot models list` to see options.\n".utf8))
-                throw ExitCode(1)
+                // Exit 0 for the same reason as a missing permission: a bad model id
+                // is not transient, and KeepAlive would relaunch us forever.
+                throw ExitCode(0)
             }
             chosenModel = m
         } else {


### PR DESCRIPTION
## Problem

`run` throws `ExitCode(1)` when `--model` names an id that is not in the
registry. The LaunchAgent written by `parrot install --launch-at-login` sets
`KeepAlive{SuccessfulExit: false}`, so launchd relaunches the daemon, which
prints the same error and exits again.

Observed on macOS 26.4.1 after pointing the agent at an id that did not exist:

```
unknown model: whisper-large-v3-turbo-compressed
run `parrot models list` to see options.
unknown model: whisper-large-v3-turbo-compressed
run `parrot models list` to see options.
unknown model: whisper-large-v3-turbo-compressed
```

A wrong id in a plist cannot fix itself by being retried, so every relaunch is
guaranteed to fail the same way. Dictation is silently dead while launchd spins.

## Fix

Exit 0. The user still gets the message and the pointer to `parrot models list`,
once instead of on a loop.

## Relationship to the accessibility path

This is the same defect in a second place — a non-transient failure exiting
nonzero under `KeepAlive`. The accessibility case is the one users are more
likely to hit (a new release invalidates the TCC grant, since the shipped
binaries are `adhoc, linker-signed` and TCC then anchors to the cdhash), and it
produced nine permission dialogs in a row on this machine. Both fixes are
one-liners and independent; either can land alone.

Built locally with `swift build -c release` (no PR CI in this repo); clean, no
warnings.
