### PR TITLE
Prevent duplicate text injection on key release

### DIFF
--- a/Sources/parrot/Input/TextInjector.swift
+++ b/Sources/parrot/Input/TextInjector.swift
@@ -33,7 +33,6 @@ enum TextInjector {
         down?.post(tap: .cgSessionEventTap)
 
         let up = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: false)
-        up?.keyboardSetUnicodeString(stringLength: length, unicodeString: &chunk)
         up?.post(tap: .cgSessionEventTap)
     }
 }


### PR DESCRIPTION
## Summary

- Attach transcript Unicode only to the synthesized key-down event
- Keep the matching key-up event without a text payload

## Why

The injector currently attaches the same Unicode chunk to both key-down and key-up events. Some text inputs can interpret both payloads, causing intermittent duplicate insertion even though Parrot produced a single transcription.

## Testing

- swift build -c release