### PR TITLE
Add Parakeet service adapter

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,5 +16,9 @@ let package = Package(
                 .product(name: "WhisperKit", package: "WhisperKit"),
             ]
         ),
+        .testTarget(
+            name: "parrotTests",
+            dependencies: ["parrot"]
+        ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -36,14 +36,51 @@ parrot doctor                          # check permissions + fn key setting
 parrot models list                     # list available models
 parrot models download <id>            # pre-download a model
 parrot --model whisper-large-v3-turbo  # bigger, multilingual, slower first-run
+parrot run --model parakeet-tdt-0.6b-v3 --parakeet-url http://127.0.0.1:5092
 parrot --hotkey right-option           # change the push-to-talk key
 parrot --no-overlay                    # disable the bottom-of-screen pill
 ```
+
+## Parakeet local service (optional)
+
+WhisperKit remains the recommended default. `parakeet-tdt-0.6b-v3` instead
+uses a user-managed local HTTP service; Parrot neither installs Docker nor
+downloads the service's model files. Start the pinned server bound only to
+loopback:
+
+```sh
+docker run -d --rm --name parrot-parakeet -p 127.0.0.1:5092:5092 \
+  -e PARAKEET_WORKERS=1 \
+  ghcr.io/achetronic/parakeet:0.8.0-int8
+curl http://127.0.0.1:5092/health
+parrot run --model parakeet-tdt-0.6b-v3
+```
+
+When finished, run `docker stop parrot-parakeet`; `--rm` removes the stopped
+container automatically.
+
+The health endpoint must return `{"status":"ok"}` before Parrot starts.
+Only `127.0.0.1`, `localhost`, and `::1` URLs are accepted; use
+`--parakeet-url` to select another port or loopback spelling. If the service
+uses bearer authentication, set `PARROT_PARAKEET_API_KEY` in the environment;
+do not place the token on the command line.
+
+The measured Apple Silicon Docker runtime reached health in about two seconds,
+used up to 1.47 GiB on short fixtures (reserve 2 GiB per worker), and had
+post-upload p95 latency of 309 ms for five-second clips and 397 ms for
+ten-second clips. This is CPU/ONNX Runtime inference, not WhisperKit's
+CoreML/ANE path. The runtime evidence does not establish a quality comparison
+with WhisperKit.
+
+The server is [Apache-2.0](https://github.com/achetronic/parakeet) and its
+converted NVIDIA Parakeet TDT 0.6B v3 ONNX model is
+[CC-BY-4.0](https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx).
 
 ## Stack
 
 - **Swift** — single SPM executable target
 - **WhisperKit** — Whisper inference via CoreML, ANE-accelerated
+- **Parakeet service adapter** — optional loopback HTTP transcription
 - **AVAudioEngine** — mic capture
 - **CGEventTap** — global hotkey
 - **CGEvent** — text injection at cursor

--- a/Sources/parrot/Adapters/ParakeetAdapter.swift
+++ b/Sources/parrot/Adapters/ParakeetAdapter.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+protocol ParakeetAdapter: Sendable {
+    func checkHealth() async throws
+    func transcribe(samples: [Float], sampleRate: Double) async throws -> String
+}

--- a/Sources/parrot/Adapters/ParakeetHTTPAdapter.swift
+++ b/Sources/parrot/Adapters/ParakeetHTTPAdapter.swift
@@ -1,0 +1,284 @@
+import Foundation
+
+struct ParakeetConfiguration {
+    static let defaultURL = "http://127.0.0.1:5092"
+    static let defaultMaximumWAVBytes = 25 * 1024 * 1024
+
+    let baseURL: URL
+    let apiKey: String?
+    let startupTimeout: TimeInterval
+    let transcriptionTimeout: TimeInterval
+    let maximumWAVBytes: Int
+
+    init(
+        urlString: String,
+        apiKey: String? = nil,
+        startupTimeout: TimeInterval = 30,
+        transcriptionTimeout: TimeInterval = 15,
+        maximumWAVBytes: Int = ParakeetConfiguration.defaultMaximumWAVBytes
+    ) throws {
+        guard
+            let components = URLComponents(string: urlString),
+            let scheme = components.scheme?.lowercased(),
+            ["http", "https"].contains(scheme),
+            let host = components.host?.lowercased(),
+            ["127.0.0.1", "localhost", "::1", "[::1]"].contains(host),
+            let port = components.port,
+            (1...65_535).contains(port),
+            components.user == nil,
+            components.password == nil,
+            components.query == nil,
+            components.fragment == nil,
+            components.path.isEmpty || components.path == "/",
+            let baseURL = components.url
+        else {
+            throw ParakeetError.invalidEndpoint
+        }
+
+        self.baseURL = baseURL
+        self.apiKey = apiKey?.isEmpty == false ? apiKey : nil
+        self.startupTimeout = startupTimeout
+        self.transcriptionTimeout = transcriptionTimeout
+        self.maximumWAVBytes = maximumWAVBytes
+    }
+}
+
+enum ParakeetError: LocalizedError, CustomStringConvertible {
+    case invalidEndpoint
+    case connection(String)
+    case timeout(String)
+    case unauthorized
+    case redirect(status: Int)
+    case clientFailure(status: Int, type: String?, message: String?)
+    case serverFailure(status: Int, type: String?, message: String?)
+    case malformedHealth
+    case malformedResponse
+    case unexpectedResponse
+    case audioTooLarge(limit: Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidEndpoint:
+            return "Parakeet URL must be an HTTP(S) loopback URL with an explicit port."
+        case .connection(let operation):
+            return "Could not reach the local Parakeet service while \(operation)."
+        case .timeout(let operation):
+            return "The local Parakeet service timed out while \(operation)."
+        case .unauthorized:
+            return "Parakeet rejected the API key; check PARROT_PARAKEET_API_KEY."
+        case .redirect(let status):
+            return "Parakeet redirected a local request (HTTP \(status)); redirects are blocked."
+        case .clientFailure(let status, let type, let message):
+            return Self.failureDescription("Parakeet rejected the request", status, type, message)
+        case .serverFailure(let status, let type, let message):
+            return Self.failureDescription("Parakeet service failed", status, type, message)
+        case .malformedHealth:
+            return "Parakeet health response was invalid; expected {\"status\":\"ok\"}."
+        case .malformedResponse:
+            return "Parakeet transcription response was invalid; expected JSON text."
+        case .unexpectedResponse:
+            return "Parakeet returned a non-HTTP response."
+        case .audioTooLarge(let limit):
+            return "Captured audio exceeds Parakeet's \(limit / 1024 / 1024) MiB upload limit."
+        }
+    }
+
+    var description: String {
+        errorDescription ?? "Parakeet service error."
+    }
+
+    private static func failureDescription(
+        _ prefix: String,
+        _ status: Int,
+        _ type: String?,
+        _ message: String?
+    ) -> String {
+        let detail = type.map { ", \($0)" } ?? ""
+        let base = "\(prefix) (HTTP \(status)\(detail))"
+        return message.map { "\(base): \($0)" } ?? "\(base)."
+    }
+}
+
+final class ParakeetHTTPAdapter: ParakeetAdapter, @unchecked Sendable {
+    private let configuration: ParakeetConfiguration
+    private let session: URLSession
+    private let redirectDelegate: RedirectBlockingDelegate?
+
+    init(configuration: ParakeetConfiguration, session: URLSession? = nil) {
+        self.configuration = configuration
+        if let session {
+            self.session = session
+            redirectDelegate = nil
+        } else {
+            let production = Self.makeProductionSession()
+            self.redirectDelegate = production.redirectDelegate
+            self.session = production.session
+        }
+    }
+
+    static func makeProductionSession() -> (session: URLSession, redirectDelegate: RedirectBlockingDelegate) {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.connectionProxyDictionary = [:]
+        let redirectDelegate = RedirectBlockingDelegate()
+        let session = URLSession(
+            configuration: configuration,
+            delegate: redirectDelegate,
+            delegateQueue: nil
+        )
+        return (session, redirectDelegate)
+    }
+
+    func checkHealth() async throws {
+        var request = URLRequest(url: endpoint("health"))
+        request.httpMethod = "GET"
+        request.timeoutInterval = configuration.startupTimeout
+        authorize(&request)
+        let (data, response) = try await perform(request, operation: "checking readiness")
+        try validate(status: response.statusCode, data: data)
+
+        guard
+            let health = try? JSONDecoder().decode(HealthResponse.self, from: data),
+            health.status == "ok"
+        else {
+            throw ParakeetError.malformedHealth
+        }
+    }
+
+    func transcribe(samples: [Float], sampleRate: Double) async throws -> String {
+        let maximumSamples = (configuration.maximumWAVBytes - 44) / 2
+        guard samples.count <= maximumSamples else {
+            throw ParakeetError.audioTooLarge(limit: configuration.maximumWAVBytes)
+        }
+        let wav = WAVEncoder.data(samples: samples, sampleRate: Int(sampleRate.rounded()))
+        guard wav.count <= configuration.maximumWAVBytes else {
+            throw ParakeetError.audioTooLarge(limit: configuration.maximumWAVBytes)
+        }
+
+        let boundary = "Parrot-\(UUID().uuidString)"
+        var request = URLRequest(url: endpoint("v1/audio/transcriptions"))
+        request.httpMethod = "POST"
+        request.timeoutInterval = configuration.transcriptionTimeout
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        authorize(&request)
+        request.httpBody = multipartBody(wav: wav, boundary: boundary)
+
+        let (data, response) = try await perform(request, operation: "transcribing")
+        try validate(status: response.statusCode, data: data)
+        guard let transcription = try? JSONDecoder().decode(TranscriptionResponse.self, from: data) else {
+            throw ParakeetError.malformedResponse
+        }
+        return transcription.text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func endpoint(_ path: String) -> URL {
+        configuration.baseURL.appendingPathComponent(path)
+    }
+
+    private func authorize(_ request: inout URLRequest) {
+        if let apiKey = configuration.apiKey {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+    }
+
+    private func perform(
+        _ request: URLRequest,
+        operation: String
+    ) async throws -> (Data, HTTPURLResponse) {
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let response = response as? HTTPURLResponse else {
+                throw ParakeetError.unexpectedResponse
+            }
+            return (data, response)
+        } catch let error as ParakeetError {
+            throw error
+        } catch let error as URLError {
+            if error.code == .timedOut {
+                throw ParakeetError.timeout(operation)
+            }
+            throw ParakeetError.connection(operation)
+        } catch {
+            throw ParakeetError.connection(operation)
+        }
+    }
+
+    private func validate(status: Int, data: Data) throws {
+        guard status == 200 else {
+            if (300...399).contains(status) { throw ParakeetError.redirect(status: status) }
+            if status == 401 || status == 403 { throw ParakeetError.unauthorized }
+            let upstream = (try? JSONDecoder().decode(UpstreamError.self, from: data))?.error
+            let type = Self.sanitizedField(upstream?.type, maximumBytes: 80)
+            let message = Self.sanitizedField(upstream?.message, maximumBytes: 240)
+            if (400...499).contains(status) {
+                throw ParakeetError.clientFailure(status: status, type: type, message: message)
+            }
+            throw ParakeetError.serverFailure(status: status, type: type, message: message)
+        }
+    }
+
+    private static func sanitizedField(_ value: String?, maximumBytes: Int) -> String? {
+        guard let value else { return nil }
+        var withoutControls = ""
+        for scalar in value.unicodeScalars where scalar.properties.generalCategory != .control {
+            withoutControls.unicodeScalars.append(scalar)
+        }
+        let normalized = withoutControls.split(whereSeparator: { $0.isWhitespace }).joined(separator: " ")
+        guard !normalized.isEmpty else { return nil }
+
+        guard normalized.utf8.count > maximumBytes else { return normalized }
+        var truncated = ""
+        for scalar in normalized.unicodeScalars {
+            let next = String(scalar)
+            guard truncated.utf8.count + next.utf8.count <= maximumBytes - 3 else { break }
+            truncated.append(contentsOf: next)
+        }
+        return "\(truncated)..."
+    }
+
+    private func multipartBody(wav: Data, boundary: String) -> Data {
+        var body = Data()
+        appendField("model", value: "parakeet-tdt-0.6b", boundary: boundary, to: &body)
+        appendField("response_format", value: "json", boundary: boundary, to: &body)
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n".data(using: .utf8)!)
+        body.append("Content-Type: audio/wav\r\n\r\n".data(using: .utf8)!)
+        body.append(wav)
+        body.append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)
+        return body
+    }
+
+    private func appendField(_ name: String, value: String, boundary: String, to body: inout Data) {
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n".data(using: .utf8)!)
+        body.append("\(value)\r\n".data(using: .utf8)!)
+    }
+}
+
+final class RedirectBlockingDelegate: NSObject, URLSessionTaskDelegate {
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        completionHandler(nil)
+    }
+}
+
+private struct HealthResponse: Decodable {
+    let status: String
+}
+
+private struct TranscriptionResponse: Decodable {
+    let text: String
+}
+
+private struct UpstreamError: Decodable {
+    struct Detail: Decodable {
+        let message: String?
+        let type: String?
+    }
+
+    let error: Detail?
+}

--- a/Sources/parrot/Audio/AudioCapture.swift
+++ b/Sources/parrot/Audio/AudioCapture.swift
@@ -119,11 +119,11 @@ final class AudioCapture {
     }
 }
 
-// MARK: - WAV writer (for debugging M3 captures)
+// MARK: - WAV encoding and writer (for debugging M3 captures)
 
-enum WAVWriter {
-    /// Write Float32 mono samples as 16-bit PCM WAV to `path`.
-    static func write(samples: [Float], sampleRate: Int, to path: String) throws {
+enum WAVEncoder {
+    /// Encodes Float32 mono samples as a 16-bit PCM WAV in memory.
+    static func data(samples: [Float], sampleRate: Int) -> Data {
         let bytesPerSample = 2
         let dataSize = samples.count * bytesPerSample
 
@@ -132,32 +132,40 @@ enum WAVWriter {
         data.append(uint32LE(36 + UInt32(dataSize)))
         data.append(contentsOf: Array("WAVE".utf8))
         data.append(contentsOf: Array("fmt ".utf8))
-        data.append(uint32LE(16))                       // fmt chunk size
-        data.append(uint16LE(1))                        // PCM
-        data.append(uint16LE(1))                        // mono
+        data.append(uint32LE(16))
+        data.append(uint16LE(1))
+        data.append(uint16LE(1))
         data.append(uint32LE(UInt32(sampleRate)))
         data.append(uint32LE(UInt32(sampleRate * bytesPerSample)))
-        data.append(uint16LE(UInt16(bytesPerSample)))   // block align
-        data.append(uint16LE(16))                       // bits per sample
+        data.append(uint16LE(UInt16(bytesPerSample)))
+        data.append(uint16LE(16))
         data.append(contentsOf: Array("data".utf8))
         data.append(uint32LE(UInt32(dataSize)))
 
-        for s in samples {
-            let clamped = max(-1.0, min(1.0, s))
-            let i = Int16(clamped * 32767.0)
-            data.append(uint16LE(UInt16(bitPattern: i)))
+        for sample in samples {
+            let clamped = max(-1.0, min(1.0, sample))
+            let value = Int16(clamped * 32767.0)
+            data.append(uint16LE(UInt16(bitPattern: value)))
         }
-
-        try data.write(to: URL(fileURLWithPath: path))
+        return data
     }
 
-    private static func uint32LE(_ v: UInt32) -> Data {
-        var x = v.littleEndian
-        return Data(bytes: &x, count: 4)
+    private static func uint32LE(_ value: UInt32) -> Data {
+        var littleEndian = value.littleEndian
+        return Data(bytes: &littleEndian, count: 4)
     }
-    private static func uint16LE(_ v: UInt16) -> Data {
-        var x = v.littleEndian
-        return Data(bytes: &x, count: 2)
+
+    private static func uint16LE(_ value: UInt16) -> Data {
+        var littleEndian = value.littleEndian
+        return Data(bytes: &littleEndian, count: 2)
+    }
+}
+
+enum WAVWriter {
+    /// Write Float32 mono samples as 16-bit PCM WAV to `path`.
+    static func write(samples: [Float], sampleRate: Int, to path: String) throws {
+        try WAVEncoder.data(samples: samples, sampleRate: sampleRate)
+            .write(to: URL(fileURLWithPath: path))
     }
 }
 

--- a/Sources/parrot/Models/ModelRegistry.swift
+++ b/Sources/parrot/Models/ModelRegistry.swift
@@ -34,6 +34,15 @@ enum ModelRegistry {
             languages: ["en"],
             recommended: false
         ),
+        TranscriptionModel(
+            id: "parakeet-tdt-0.6b-v3",
+            displayName: "Parakeet TDT 0.6B v3 (local service)",
+            engine: .parakeet,
+            whisperKitID: nil,
+            sizeMB: 670,
+            languages: ["en"],
+            recommended: false
+        ),
     ]
 
     static func find(_ id: String) -> TranscriptionModel? {

--- a/Sources/parrot/Parrot.swift
+++ b/Sources/parrot/Parrot.swift
@@ -34,6 +34,9 @@ struct Run: ParsableCommand {
     @Option(name: .long, help: "Model id to use. Defaults to the recommended model.")
     var model: String?
 
+    @Option(name: .long, help: "Parakeet loopback service URL. Defaults to http://127.0.0.1:5092.")
+    var parakeetURL: String = ParakeetConfiguration.defaultURL
+
     func run() throws {
         if !skipDoctor {
             let checks = DoctorReport.run()
@@ -61,12 +64,16 @@ struct Run: ParsableCommand {
             chosenModel = m
         }
 
-        let transcriber = WhisperKitTranscriber(model: chosenModel)
+        let transcriber = try TranscriberFactory.make(
+            model: chosenModel,
+            parakeetURL: parakeetURL,
+            parakeetAPIKey: ProcessInfo.processInfo.environment["PARROT_PARAKEET_API_KEY"]
+        )
         let warmupSemaphore = DispatchSemaphore(value: 0)
         var warmupError: Error?
         Task.detached {
             do {
-                try await transcriber.warmUp()
+                try await transcriber.prepare()
             } catch {
                 warmupError = error
             }
@@ -215,12 +222,19 @@ struct Models: ParsableCommand {
                 print("unknown model: \(id)")
                 throw ExitCode(1)
             }
+            guard m.engine == .whisperKit else {
+                print("Parakeet model files are managed by the upstream local service; Parrot does not download them.")
+                print("Start the pinned loopback service:")
+                print("docker run --rm -p 127.0.0.1:5092:5092 -e PARAKEET_WORKERS=1 ghcr.io/achetronic/parakeet:0.8.0-int8")
+                throw ExitCode(64)
+            }
+
             let t = WhisperKitTranscriber(model: m)
 
             let sem = DispatchSemaphore(value: 0)
             var capturedError: Error?
             Task.detached {
-                do { try await t.warmUp() } catch { capturedError = error }
+                do { try await t.prepare() } catch { capturedError = error }
                 sem.signal()
             }
             sem.wait()

--- a/Sources/parrot/Transcription/ParakeetTranscriber.swift
+++ b/Sources/parrot/Transcription/ParakeetTranscriber.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+final class ParakeetTranscriber: Transcriber, @unchecked Sendable {
+    let modelID: String
+    private let adapter: any ParakeetAdapter
+
+    init(modelID: String, adapter: any ParakeetAdapter) {
+        self.modelID = modelID
+        self.adapter = adapter
+    }
+
+    func prepare() async throws {
+        try await adapter.checkHealth()
+    }
+
+    func transcribe(_ audio: [Float]) async throws -> String {
+        try await adapter.transcribe(
+            samples: audio,
+            sampleRate: AudioCapture.targetSampleRate
+        )
+    }
+}

--- a/Sources/parrot/Transcription/Transcriber.swift
+++ b/Sources/parrot/Transcription/Transcriber.swift
@@ -1,6 +1,7 @@
 import Foundation
 
-protocol Transcriber {
+protocol Transcriber: Sendable {
     var modelID: String { get }
+    func prepare() async throws
     func transcribe(_ audio: [Float]) async throws -> String
 }

--- a/Sources/parrot/Transcription/TranscriberFactory.swift
+++ b/Sources/parrot/Transcription/TranscriberFactory.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+enum TranscriberFactory {
+    static func make(
+        model: TranscriptionModel,
+        parakeetURL: String = ParakeetConfiguration.defaultURL,
+        parakeetAPIKey: String? = nil
+    ) throws -> any Transcriber {
+        switch model.engine {
+        case .whisperKit:
+            return WhisperKitTranscriber(model: model)
+        case .parakeet:
+            let configuration = try ParakeetConfiguration(
+                urlString: parakeetURL,
+                apiKey: parakeetAPIKey
+            )
+            let adapter = ParakeetHTTPAdapter(configuration: configuration)
+            return ParakeetTranscriber(modelID: model.id, adapter: adapter)
+        }
+    }
+}

--- a/Sources/parrot/Transcription/WhisperKitTranscriber.swift
+++ b/Sources/parrot/Transcription/WhisperKitTranscriber.swift
@@ -14,7 +14,7 @@ actor WhisperKitTranscriber: Transcriber {
     /// Loads the model into memory; downloads first if not already on disk.
     /// Call once at startup so the first hotkey press isn't blocked on model
     /// download/load.
-    func warmUp() async throws {
+    func prepare() async throws {
         if pipeline != nil { return }
         guard let whisperKitID = model.whisperKitID else {
             throw TranscriberError.missingEngineID
@@ -26,7 +26,7 @@ actor WhisperKitTranscriber: Transcriber {
     }
 
     func transcribe(_ audio: [Float]) async throws -> String {
-        if pipeline == nil { try await warmUp() }
+        if pipeline == nil { try await prepare() }
         guard let pipeline else { throw TranscriberError.notLoaded }
 
         let results = try await pipeline.transcribe(audioArray: audio)

--- a/Tests/parrotTests/ModelSelectionTests.swift
+++ b/Tests/parrotTests/ModelSelectionTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import parrot
+
+final class ModelSelectionTests: XCTestCase {
+    func testRegistryIncludesServiceBackedParakeetWithoutChangingRecommendation() {
+        let parakeet = ModelRegistry.find("parakeet-tdt-0.6b-v3")
+
+        XCTAssertEqual(parakeet?.displayName, "Parakeet TDT 0.6B v3 (local service)")
+        XCTAssertEqual(parakeet?.engine, .parakeet)
+        XCTAssertNil(parakeet?.whisperKitID)
+        XCTAssertEqual(parakeet?.sizeMB, 670)
+        XCTAssertEqual(parakeet?.languages, ["en"])
+        XCTAssertFalse(parakeet?.recommended ?? true)
+        XCTAssertEqual(ModelRegistry.recommended()?.id, "whisper-base.en")
+    }
+
+    func testFactoryDispatchesParakeetWithoutContactingService() throws {
+        let model = try XCTUnwrap(ModelRegistry.find("parakeet-tdt-0.6b-v3"))
+        let transcriber = try TranscriberFactory.make(model: model)
+
+        XCTAssertTrue(transcriber is ParakeetTranscriber)
+        XCTAssertEqual(transcriber.modelID, model.id)
+    }
+
+    func testWhisperKitFactoryIgnoresInvalidParakeetURL() throws {
+        let whisperModels = ModelRegistry.shared.filter { $0.engine == .whisperKit }
+        XCTAssertFalse(whisperModels.isEmpty)
+
+        for model in whisperModels {
+            let transcriber = try TranscriberFactory.make(
+                model: model,
+                parakeetURL: "https://remote.example:5092"
+            )
+            XCTAssertTrue(transcriber is WhisperKitTranscriber, model.id)
+            XCTAssertEqual(transcriber.modelID, model.id)
+        }
+    }
+}

--- a/Tests/parrotTests/ParakeetHTTPAdapterTests.swift
+++ b/Tests/parrotTests/ParakeetHTTPAdapterTests.swift
@@ -1,0 +1,289 @@
+import Foundation
+import XCTest
+@testable import parrot
+
+final class ParakeetHTTPAdapterTests: XCTestCase {
+    override func tearDown() {
+        StubURLProtocol.handler = nil
+        super.tearDown()
+    }
+
+    func testHealthRequiresExpectedEndpointAndPayload() async throws {
+        StubURLProtocol.handler = { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertEqual(request.url?.path, "/health")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer health-key")
+            return Self.response(for: request, status: 200, body: #"{"status":"ok"}"#)
+        }
+
+        try await adapter(apiKey: "health-key").checkHealth()
+    }
+
+    func testMapsMalformedHealthAndTransportFailures() async throws {
+        StubURLProtocol.handler = { request in
+            Self.response(for: request, status: 200, body: #"{"status":"starting"}"#)
+        }
+        do {
+            try await adapter().checkHealth()
+            XCTFail("Expected malformed health failure")
+        } catch let error as ParakeetError {
+            guard case .malformedHealth = error else { return XCTFail("Unexpected \(error)") }
+        }
+
+        StubURLProtocol.handler = { _ in throw URLError(.timedOut) }
+        do {
+            try await adapter().checkHealth()
+            XCTFail("Expected timeout failure")
+        } catch let error as ParakeetError {
+            guard case .timeout = error else { return XCTFail("Unexpected \(error)") }
+        }
+
+        StubURLProtocol.handler = { _ in throw URLError(.cannotConnectToHost) }
+        do {
+            try await adapter().checkHealth()
+            XCTFail("Expected connection failure")
+        } catch let error as ParakeetError {
+            guard case .connection = error else { return XCTFail("Unexpected \(error)") }
+        }
+    }
+
+    func testRedirectDelegateAndAdapterRefuseRedirects() async throws {
+        let production = ParakeetHTTPAdapter.makeProductionSession()
+        let session = production.session
+        let delegate = production.redirectDelegate
+        defer { session.invalidateAndCancel() }
+        XCTAssertTrue(session.configuration.connectionProxyDictionary?.isEmpty ?? false)
+        let task = session.dataTask(with: URL(string: "http://127.0.0.1:5092/health")!)
+        let response = HTTPURLResponse(
+            url: URL(string: "http://127.0.0.1:5092/health")!,
+            statusCode: 307,
+            httpVersion: nil,
+            headerFields: ["Location": "https://example.com/v1/audio/transcriptions"]
+        )!
+        var redirectedRequest: URLRequest?
+
+        delegate.urlSession(
+            session,
+            task: task,
+            willPerformHTTPRedirection: response,
+            newRequest: URLRequest(url: URL(string: "https://example.com/v1/audio/transcriptions")!)
+        ) { redirectedRequest = $0 }
+        XCTAssertNil(redirectedRequest)
+
+        StubURLProtocol.handler = { request in
+            XCTAssertEqual(request.url?.host, "127.0.0.1")
+            return Self.response(for: request, status: 307, body: "")
+        }
+        do {
+            _ = try await adapter().transcribe(samples: [], sampleRate: 16_000)
+            XCTFail("Expected redirect failure")
+        } catch let error as ParakeetError {
+            guard case .redirect(let status) = error else { return XCTFail("Unexpected \(error)") }
+            XCTAssertEqual(status, 307)
+            XCTAssertEqual(
+                error.errorDescription,
+                "Parakeet redirected a local request (HTTP 307); redirects are blocked."
+            )
+        }
+    }
+
+    func testTranscriptionUploadsMultipartWAVWithAuthAndTrimsText() async throws {
+        StubURLProtocol.handler = { request in
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.url?.path, "/v1/audio/transcriptions")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer test-key")
+            XCTAssertTrue(request.value(forHTTPHeaderField: "Content-Type")?.hasPrefix("multipart/form-data; boundary=Parrot-") ?? false)
+            let body = try XCTUnwrap(Self.requestBody(from: request))
+            XCTAssertTrue(body.range(of: Data("name=\"model\"\r\n\r\nparakeet-tdt-0.6b".utf8)) != nil)
+            XCTAssertTrue(body.range(of: Data("name=\"response_format\"\r\n\r\njson".utf8)) != nil)
+            XCTAssertTrue(body.range(of: Data("filename=\"audio.wav\"".utf8)) != nil)
+            XCTAssertTrue(body.range(of: Data("Content-Type: audio/wav".utf8)) != nil)
+            XCTAssertTrue(body.range(of: Data("RIFF".utf8)) != nil)
+            return Self.response(for: request, status: 200, body: #"{"text":"  hello world \n"}"#)
+        }
+
+        let text = try await adapter(apiKey: "test-key").transcribe(samples: [0, 0.5], sampleRate: 16_000)
+
+        XCTAssertEqual(text, "hello world")
+    }
+
+    func testEmptyTextIsSuccessfulSilenceResult() async throws {
+        StubURLProtocol.handler = { request in
+            Self.response(for: request, status: 200, body: #"{"text":""}"#)
+        }
+
+        let text = try await adapter().transcribe(samples: [], sampleRate: 16_000)
+        XCTAssertEqual(text, "")
+    }
+
+    func testMapsUnauthorizedAndStructuredFailuresWithBoundedMessage() async throws {
+        StubURLProtocol.handler = { request in
+            Self.response(for: request, status: 403, body: #"{"error":{"type":"authentication_error","message":"secret"}}"#)
+        }
+        do {
+            _ = try await adapter().transcribe(samples: [], sampleRate: 16_000)
+            XCTFail("Expected authorization failure")
+        } catch let error as ParakeetError {
+            guard case .unauthorized = error else { return XCTFail("Unexpected \(error)") }
+        }
+
+        StubURLProtocol.handler = { request in
+            Self.response(
+                for: request,
+                status: 500,
+                body: #"{"error":{"type":"server_error","message":"Transcription failed: \naudio too long for a single pass; enable long-audio mode"}}"#
+            )
+        }
+        do {
+            _ = try await adapter().transcribe(samples: [], sampleRate: 16_000)
+            XCTFail("Expected server failure")
+        } catch let error as ParakeetError {
+            guard case .serverFailure(let status, let type, let message) = error else { return XCTFail("Unexpected \(error)") }
+            XCTAssertEqual(status, 500)
+            XCTAssertEqual(type, "server_error")
+            XCTAssertEqual(message, "Transcription failed: audio too long for a single pass; enable long-audio mode")
+            XCTAssertEqual(
+                error.errorDescription,
+                "Parakeet service failed (HTTP 500, server_error): Transcription failed: audio too long for a single pass; enable long-audio mode"
+            )
+        }
+
+        StubURLProtocol.handler = { request in
+            Self.response(for: request, status: 400, body: #"{"error":{"type":"invalid_request_error"}}"#)
+        }
+        do {
+            _ = try await adapter().transcribe(samples: [], sampleRate: 16_000)
+            XCTFail("Expected client failure")
+        } catch let error as ParakeetError {
+            guard case .clientFailure(let status, let type, let message) = error else { return XCTFail("Unexpected \(error)") }
+            XCTAssertEqual(status, 400)
+            XCTAssertEqual(type, "invalid_request_error")
+            XCTAssertNil(message)
+        }
+
+        let longType = String(repeating: "t", count: 120) + "\u{001B}\u{0000}\nsecond type"
+        let longMessage = String(repeating: "x", count: 500) + "\u{0000}\nsecond line"
+        StubURLProtocol.handler = { request in
+            Self.response(
+                for: request,
+                status: 500,
+                body: Self.structuredErrorBody(type: longType, message: longMessage)
+            )
+        }
+        do {
+            _ = try await adapter().transcribe(samples: [], sampleRate: 16_000)
+            XCTFail("Expected bounded server failure")
+        } catch let error as ParakeetError {
+            guard case .serverFailure(_, let type, let message) = error else { return XCTFail("Unexpected \(error)") }
+            XCTAssertLessThanOrEqual(type?.utf8.count ?? 0, 80)
+            XCTAssertFalse(type?.unicodeScalars.contains(where: { $0.properties.generalCategory == .control }) ?? true)
+            XCTAssertFalse(type?.contains("\n") ?? true)
+            XCTAssertTrue(type?.hasSuffix("...") ?? false)
+            XCTAssertLessThanOrEqual(message?.utf8.count ?? 0, 240)
+            XCTAssertFalse(message?.unicodeScalars.contains(where: { $0.properties.generalCategory == .control }) ?? true)
+            XCTAssertTrue(message?.hasSuffix("...") ?? false)
+            XCTAssertFalse(error.errorDescription?.unicodeScalars.contains(where: { $0.properties.generalCategory == .control }) ?? true)
+        }
+    }
+
+    func testRejectsOversizedWAVBeforeRequest() async throws {
+        let smallLimit = 45
+        let configuration = try ParakeetConfiguration(
+            urlString: ParakeetConfiguration.defaultURL,
+            maximumWAVBytes: smallLimit
+        )
+        let adapter = ParakeetHTTPAdapter(configuration: configuration, session: session())
+
+        do {
+            _ = try await adapter.transcribe(samples: [0], sampleRate: 16_000)
+            XCTFail("Expected audio size failure")
+        } catch let error as ParakeetError {
+            guard case .audioTooLarge(let limit) = error else { return XCTFail("Unexpected \(error)") }
+            XCTAssertEqual(limit, smallLimit)
+        }
+    }
+
+    func testConfigurationAllowsOnlyExplicitLoopbackRoots() throws {
+        XCTAssertNoThrow(try ParakeetConfiguration(urlString: "https://localhost:5092/"))
+        XCTAssertNoThrow(try ParakeetConfiguration(urlString: "http://[::1]:5092"))
+        for url in [
+            "http://example.com:5092",
+            "http://127.0.0.1",
+            "http://user:pass@127.0.0.1:5092",
+            "http://127.0.0.1:5092/v1",
+            "http://127.0.0.1:5092?debug=1",
+            "http://127.0.0.1:5092#fragment",
+        ] {
+            XCTAssertThrowsError(try ParakeetConfiguration(urlString: url), "Expected \(url) to be rejected")
+        }
+    }
+
+    private func adapter(apiKey: String? = nil) -> ParakeetHTTPAdapter {
+        let configuration = try! ParakeetConfiguration(
+            urlString: ParakeetConfiguration.defaultURL,
+            apiKey: apiKey
+        )
+        return ParakeetHTTPAdapter(configuration: configuration, session: session())
+    }
+
+    private func session() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    private static func response(
+        for request: URLRequest,
+        status: Int,
+        body: String
+    ) -> (HTTPURLResponse, Data) {
+        let response = HTTPURLResponse(
+            url: try! XCTUnwrap(request.url),
+            statusCode: status,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        return (response, Data(body.utf8))
+    }
+
+    private static func structuredErrorBody(type: String, message: String) -> String {
+        let payload = ["error": ["type": type, "message": message]]
+        return String(data: try! JSONSerialization.data(withJSONObject: payload), encoding: .utf8)!
+    }
+
+    private static func requestBody(from request: URLRequest) -> Data? {
+        if let body = request.httpBody { return body }
+        guard let stream = request.httpBodyStream else { return nil }
+        stream.open()
+        defer { stream.close() }
+        var body = Data()
+        var buffer = [UInt8](repeating: 0, count: 4_096)
+        while stream.hasBytesAvailable {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            guard count > 0 else { break }
+            body.append(buffer, count: count)
+        }
+        return body.isEmpty ? nil : body
+    }
+}
+
+private final class StubURLProtocol: URLProtocol {
+    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        do {
+            let handler = try XCTUnwrap(Self.handler)
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}

--- a/Tests/parrotTests/ParakeetTranscriberTests.swift
+++ b/Tests/parrotTests/ParakeetTranscriberTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import parrot
+
+final class ParakeetTranscriberTests: XCTestCase {
+    func testDelegatesPreparationAndSamplesToAdapter() async throws {
+        let adapter = FakeParakeetAdapter(result: "transcript")
+        let transcriber = ParakeetTranscriber(modelID: "parakeet-tdt-0.6b-v3", adapter: adapter)
+        let samples: [Float] = [0.25, -0.5]
+
+        try await transcriber.prepare()
+        let result = try await transcriber.transcribe(samples)
+
+        XCTAssertEqual(result, "transcript")
+        XCTAssertEqual(transcriber.modelID, "parakeet-tdt-0.6b-v3")
+        let healthChecks = await adapter.healthChecks
+        let transcribedSamples = await adapter.transcribedSamples
+        let sampleRate = await adapter.sampleRate
+        XCTAssertEqual(healthChecks, 1)
+        XCTAssertEqual(transcribedSamples, samples)
+        XCTAssertEqual(sampleRate, AudioCapture.targetSampleRate)
+    }
+}
+
+private actor FakeParakeetAdapter: ParakeetAdapter {
+    private(set) var healthChecks = 0
+    private(set) var transcribedSamples: [Float] = []
+    private(set) var sampleRate = 0.0
+    let result: String
+
+    init(result: String) {
+        self.result = result
+    }
+
+    func checkHealth() {
+        healthChecks += 1
+    }
+
+    func transcribe(samples: [Float], sampleRate: Double) -> String {
+        transcribedSamples = samples
+        self.sampleRate = sampleRate
+        return result
+    }
+}

--- a/Tests/parrotTests/WAVEncoderTests.swift
+++ b/Tests/parrotTests/WAVEncoderTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import parrot
+
+final class WAVEncoderTests: XCTestCase {
+    func testEncodes16BitMonoWAVAndClampsSamples() {
+        let wav = WAVEncoder.data(samples: [-2, 0, 2], sampleRate: 16_000)
+
+        XCTAssertEqual(wav.count, 50)
+        XCTAssertEqual(String(decoding: wav[0..<4], as: UTF8.self), "RIFF")
+        XCTAssertEqual(String(decoding: wav[8..<12], as: UTF8.self), "WAVE")
+        XCTAssertEqual(uint16(wav, at: 22), 1)
+        XCTAssertEqual(uint32(wav, at: 24), 16_000)
+        XCTAssertEqual(uint16(wav, at: 34), 16)
+        XCTAssertEqual(Int16(bitPattern: uint16(wav, at: 44)), -32_767)
+        XCTAssertEqual(Int16(bitPattern: uint16(wav, at: 46)), 0)
+        XCTAssertEqual(Int16(bitPattern: uint16(wav, at: 48)), 32_767)
+    }
+
+    private func uint16(_ data: Data, at offset: Int) -> UInt16 {
+        UInt16(data[offset]) | UInt16(data[offset + 1]) << 8
+    }
+
+    private func uint32(_ data: Data, at offset: Int) -> UInt32 {
+        UInt32(data[offset])
+            | UInt32(data[offset + 1]) << 8
+            | UInt32(data[offset + 2]) << 16
+            | UInt32(data[offset + 3]) << 24
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,9 +5,9 @@
 1. **CLI executable.** Single binary, launched from the terminal. No menubar, no dock icon, no settings window.
 2. **Push-to-talk.** Hold Fn, speak, release — transcript appears at the cursor.
 3. **Minimal recording feedback.** A small floating pill at the bottom of the screen while recording, so the user knows the mic is hot. Click-through, borderless, hidden when idle.
-4. **On-device.** No network calls for transcription. Audio never leaves the machine.
-5. **Pluggable models.** Whisper out of the box; Parakeet (or future engines) via a JSON-driven registry.
-6. **Native and lean.** One Swift Package executable target. No sidecar processes. No HTTP servers.
+4. **Local audio boundary.** WhisperKit runs in-process; optional Parakeet calls stay on a validated loopback service. Audio never leaves the machine.
+5. **Pluggable models.** Whisper out of the box; Parakeet is a user-managed local-service option.
+6. **Native and lean.** One Swift Package executable target. Parrot starts no sidecar process or HTTP server.
 
 ## Non-goals
 
@@ -20,7 +20,7 @@
 
 ## Why Swift
 
-- **CoreML / ANE access.** WhisperKit and FluidAudio are Swift-native and run inference on the Apple Neural Engine — lower power, lower latency than CPU/GPU paths in Rust.
+- **CoreML / ANE access.** WhisperKit runs in process through CoreML and the Apple Neural Engine; the selected Parakeet service uses CPU/ONNX Runtime.
 - **No FFI for platform APIs.** `AVAudioEngine`, `CGEventTap`, `CGEvent`, `AXIsProcessTrusted`, `NSWindow` — all first-party, no bindings to maintain.
 - **Permissions plumbing** (microphone, accessibility) is dramatically smoother in a Swift binary than via Rust crates.
 - **AppKit overlay for free.** The recording indicator (see below) is a borderless `NSWindow` — trivial in Swift, awkward in Rust.
@@ -50,9 +50,13 @@ $ parrot
                                     │  │ WhisperKit │  │
                                     │  └────────────┘  │
                                     │  ┌────────────┐  │
-                                    │  │  Parakeet  │  │
+                                    │  │  Parakeet  │──┼── loopback HTTP
                                     │  └────────────┘  │
                                     └────────┬─────────┘
+                                             │            ┌──────────────────┐
+                                             │            │ User-managed     │
+                                             │            │ Parakeet service │
+                                             │            └──────────────────┘
                                              │ String
                                              ▼
                                     ┌──────────────────┐
@@ -87,6 +91,7 @@ Global hotkey via `CGEventTap` (requires Accessibility permission). Default: **h
 
 ```swift
 protocol Transcriber {
+    func prepare() async throws
     func transcribe(_ audio: [Float]) async throws -> String
     var modelID: String { get }
 }
@@ -95,7 +100,11 @@ protocol Transcriber {
 Concrete implementations:
 
 - `WhisperKitTranscriber` — wraps the `WhisperKit` package. CoreML, ANE-accelerated.
-- `ParakeetTranscriber` — wraps `FluidAudio` (or direct CoreML) for NVIDIA Parakeet TDT.
+- `ParakeetTranscriber` — a thin domain adapter that delegates readiness and
+  transcription to an injected `ParakeetAdapter`.
+- `ParakeetHTTPAdapter` — validates a loopback-only URL, health-checks the
+  user-managed service, encodes in-memory WAV multipart requests, and decodes
+  its response. It owns all HTTP and authentication details.
 
 Adding an engine = one new file conforming to `Transcriber`.
 
@@ -186,11 +195,13 @@ Initial registry:
 
 | Engine | Model | Size | Notes |
 |---|---|---|---|
-| WhisperKit | `whisper-base.en` | ~80 MB | Fast, English only, low resource |
-| WhisperKit | `whisper-large-v3-turbo` | ~800 MB | Recommended for daily use |
-| Parakeet | `parakeet-tdt-0.6b-v3` | ~600 MB | English, fastest on ANE |
+| WhisperKit | `whisper-base.en` | 145 MB | Recommended; CoreML/ANE, English |
+| WhisperKit | `whisper-large-v3-turbo` | 1,620 MB | Multilingual WhisperKit model |
+| Parakeet | `parakeet-tdt-0.6b-v3` | 670 MB | User-managed local CPU/ONNX service |
 
-Models live in `~/Library/Application Support/parrot/models/`. Not bundled — fetched on first selection or via `parrot models download`.
+WhisperKit models are fetched on first selection or via `parrot models download`.
+Parakeet model files stay with the upstream service; its download command gives
+setup guidance and exits without writing model artifacts.
 
 ## Data flow, end-to-end
 
@@ -203,7 +214,7 @@ Models live in `~/Library/Application Support/parrot/models/`. Not bundled — f
 7. User releases Fn.
 8. `HotkeyMonitor` fires `.released`. Overlay switches to spinner. Status: `transcribing`.
 9. `AudioCapture` stops, hands buffer to active `Transcriber`.
-10. `Transcriber` runs CoreML inference. Returns string.
+10. `Transcriber` runs CoreML inference or calls the selected loopback adapter. Returns string.
 11. `TextInjector` posts the string at the cursor.
 12. Overlay hides. Status: `listening`. Loop.
 13. User hits `^C`. Process exits cleanly.
@@ -236,6 +247,11 @@ parrot/
       Transcriber.swift         # protocol
       WhisperKitTranscriber.swift
       ParakeetTranscriber.swift
+      TranscriberFactory.swift
+
+    Adapters/
+      ParakeetAdapter.swift     # service-specific boundary
+      ParakeetHTTPAdapter.swift # loopback API transport
 
     Models/                     # registry + download pipeline
       ModelRegistry.swift
@@ -267,7 +283,25 @@ Swift's module unit is the **SPM target** (one target = one module = one `import
 
 ## Open questions
 
-- **Parakeet via FluidAudio vs. direct CoreML?** FluidAudio is faster to integrate but adds a dependency. Decide once we benchmark both.
+- **Native Parakeet engine.** A future FluidAudio/CoreML or other native shape
+  would require a separate investigation; the current service is CPU/ONNX
+  Runtime through user-managed Docker.
 - **Hotkey conflicts.** Right-Option is unused on most keyboards but some users remap it. Print a clear error if `CGEventTap` registration fails.
 - **First-run UX.** Bundle `whisper-base.en` so `parrot` works out of the box, or always require an explicit download? Probably the latter — keeps the binary small and the model directory clean.
 - **Code signing.** A self-built unsigned binary works fine locally but accessibility permission persistence is more reliable for signed binaries. Decide if we sign for personal distribution.
+
+## Parakeet service boundary
+
+Parakeet support targets `achetronic/parakeet` v0.8.0 at
+`http://127.0.0.1:5092` by default. Parrot permits only HTTP(S) URLs with an
+explicit port on `127.0.0.1`, `localhost`, or `::1`, and calls `/health` before
+starting the daemon. The startup request has a 30-second deadline; short
+transcriptions have a 15-second deadline and a 25 MiB encoded-WAV limit.
+
+The measured pinned image is `ghcr.io/achetronic/parakeet:0.8.0-int8`: health
+was ready in about two seconds, short-fixture p95 was 309 ms at five seconds
+and 397 ms at ten seconds, and one worker should reserve 2 GiB. The server is
+[Apache-2.0](https://github.com/achetronic/parakeet); the converted ONNX model
+is [CC-BY-4.0](https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx).
+These measurements do not establish Parakeet quality equivalence or superiority
+to WhisperKit.


### PR DESCRIPTION
   ## Summary

   Add optional Parakeet TDT 0.6B v3 support through a user-managed local HTTP service.

   ## Changes

   - Add `parakeet-tdt-0.6b-v3` to the model registry.
   - Add Parakeet transcriber and HTTP adapter.
   - Validate that service URLs use loopback hosts and explicit ports.
   - Check service health before starting transcription.
   - Upload captured audio as in-memory 16-bit PCM WAV multipart data.
   - Support bearer authentication through `PARROT_PARAKEET_API_KEY`.
   - Block redirects and enforce request and upload limits.
   - Preserve WhisperKit as the default transcription engine.
   - Add setup and usage documentation.
   - Add unit tests for model selection, request handling, validation, errors, and WAV encoding.

   ## Usage

   ```sh
   docker run -d --rm --name parrot-parakeet \
     -p 127.0.0.1:5092:5092 \
     -e PARAKEET_WORKERS=1 \
     ghcr.io/achetronic/parakeet:0.8.0-int8

   parrot run --model parakeet-tdt-0.6b-v3